### PR TITLE
fix(backup): add attachments table and validate backup integrity

### DIFF
--- a/src/__tests__/backup.test.ts
+++ b/src/__tests__/backup.test.ts
@@ -81,7 +81,7 @@ describe("backup service", () => {
       expect(new Date(backup.exportedAt).toISOString()).toBe(backup.exportedAt);
     });
 
-    test("includes all 9 table keys", async () => {
+    test("includes all 13 table keys", async () => {
       const keys = Object.keys((await buildBackup(db)).data);
       for (const key of ALL_TABLE_KEYS) {
         expect(keys).toContain(key);
@@ -201,9 +201,16 @@ describe("backup service", () => {
       );
     });
 
-    test("valid payload requires all table keys", () => {
-      // Empty data object should fail - missing required table keys
-      expect(validateBackup({ version: 1, data: {} })).toMatch(/Missing required table key/);
+    test("valid payload with missing keys backfills empty arrays", () => {
+      // Old backups without 'attachments' should still pass — missing keys get backfilled
+      const data: Record<string, unknown[]> = {};
+      for (const key of ALL_TABLE_KEYS) {
+        if (key !== "attachments") data[key] = [];
+      }
+      const payload = { version: 1, data };
+      expect(validateBackup(payload)).toBeNull();
+      // After validation, the missing key should be backfilled
+      expect((payload.data as Record<string, unknown>).attachments).toEqual([]);
     });
 
     test("valid payload with empty arrays passes", () => {
@@ -286,7 +293,7 @@ describe("backup service", () => {
       expect(memberIds).toContain(firstPolicy.applicant_id);
     });
 
-    test("restore with empty arrays preserves existing data", async () => {
+    test("restore with empty arrays clears everything", async () => {
       await seedFamily();
       expect(rawQuery("members").length).toBe(2);
 
@@ -310,12 +317,11 @@ describe("backup service", () => {
         },
       };
 
-      // When backup has empty arrays, existing data should be preserved
-      // (only tables with actual data in backup will be cleared and replaced)
+      // Empty arrays mean "this table had zero rows at backup time" — restore should clear existing data
       await restoreBackup(db, emptyBackup);
-      expect(rawQuery("members").length).toBe(2); // Data preserved
-      expect(rawQuery("policies").length).toBe(1);
-      expect(rawQuery("settings").length).toBe(2);
+      expect(rawQuery("members")).toEqual([]);
+      expect(rawQuery("policies")).toEqual([]);
+      expect(rawQuery("settings")).toEqual([]);
     });
 
     test("restore throws on invalid payload", async () => {
@@ -442,10 +448,9 @@ describe("backup service", () => {
       // Should have collected DELETE + INSERT statements
       expect(captured.length).toBeGreaterThan(0);
 
-      // Should have DELETEs only for tables that have data in the backup
+      // Should have DELETEs for all tables + sqlite_sequence
       const deleteStmts = captured.filter((s) => s.sql.startsWith("DELETE FROM"));
-      // Only tables with data: members(2), insurers(1), assets(1), policies(1), beneficiaries(1), settings(2) = 6 tables
-      expect(deleteStmts.length).toBe(6);
+      expect(deleteStmts.length).toBe(14); // 13 tables + sqlite_sequence
 
       // Should have INSERTs
       const insertStmts = captured.filter((s) => s.sql.startsWith("INSERT INTO"));

--- a/src/__tests__/backup.test.ts
+++ b/src/__tests__/backup.test.ts
@@ -201,8 +201,8 @@ describe("backup service", () => {
       );
     });
 
-    test("valid payload with missing keys backfills empty arrays", () => {
-      // Old backups without 'attachments' should still pass — missing keys get backfilled
+    test("old backup missing 'attachments' is backfilled and accepted", () => {
+      // Old backups without 'attachments' should still pass — it's a known new-table key
       const data: Record<string, unknown[]> = {};
       for (const key of ALL_TABLE_KEYS) {
         if (key !== "attachments") data[key] = [];
@@ -211,6 +211,17 @@ describe("backup service", () => {
       expect(validateBackup(payload)).toBeNull();
       // After validation, the missing key should be backfilled
       expect((payload.data as Record<string, unknown>).attachments).toEqual([]);
+    });
+
+    test("partial backup missing original v1 keys is rejected", () => {
+      // A payload with only 'attachments' and nothing else is corrupt — must be rejected
+      expect(validateBackup({ version: 1, data: { attachments: [] } })).toMatch(
+        /Missing required table key/,
+      );
+    });
+
+    test("empty data object is rejected", () => {
+      expect(validateBackup({ version: 1, data: {} })).toMatch(/Missing required table key/);
     });
 
     test("valid payload with empty arrays passes", () => {

--- a/src/__tests__/backup.test.ts
+++ b/src/__tests__/backup.test.ts
@@ -201,8 +201,9 @@ describe("backup service", () => {
       );
     });
 
-    test("valid payload passes", () => {
-      expect(validateBackup({ version: 1, data: {} })).toBeNull();
+    test("valid payload requires all table keys", () => {
+      // Empty data object should fail - missing required table keys
+      expect(validateBackup({ version: 1, data: {} })).toMatch(/Missing required table key/);
     });
 
     test("valid payload with empty arrays passes", () => {
@@ -285,7 +286,7 @@ describe("backup service", () => {
       expect(memberIds).toContain(firstPolicy.applicant_id);
     });
 
-    test("restore with empty data clears everything", async () => {
+    test("restore with empty arrays preserves existing data", async () => {
       await seedFamily();
       expect(rawQuery("members").length).toBe(2);
 
@@ -301,6 +302,7 @@ describe("backup service", () => {
           payments: [],
           cashValues: [],
           coverageItems: [],
+          attachments: [],
           settings: [],
           hospitals: [],
           doctors: [],
@@ -308,10 +310,12 @@ describe("backup service", () => {
         },
       };
 
+      // When backup has empty arrays, existing data should be preserved
+      // (only tables with actual data in backup will be cleared and replaced)
       await restoreBackup(db, emptyBackup);
-      expect(rawQuery("members")).toEqual([]);
-      expect(rawQuery("policies")).toEqual([]);
-      expect(rawQuery("settings")).toEqual([]);
+      expect(rawQuery("members").length).toBe(2); // Data preserved
+      expect(rawQuery("policies").length).toBe(1);
+      expect(rawQuery("settings").length).toBe(2);
     });
 
     test("restore throws on invalid payload", async () => {
@@ -438,9 +442,10 @@ describe("backup service", () => {
       // Should have collected DELETE + INSERT statements
       expect(captured.length).toBeGreaterThan(0);
 
-      // Should have DELETEs for all tables + sqlite_sequence
+      // Should have DELETEs only for tables that have data in the backup
       const deleteStmts = captured.filter((s) => s.sql.startsWith("DELETE FROM"));
-      expect(deleteStmts.length).toBe(13); // 12 tables + sqlite_sequence
+      // Only tables with data: members(2), insurers(1), assets(1), policies(1), beneficiaries(1), settings(2) = 6 tables
+      expect(deleteStmts.length).toBe(6);
 
       // Should have INSERTs
       const insertStmts = captured.filter((s) => s.sql.startsWith("INSERT INTO"));

--- a/src/__tests__/backup.test.ts
+++ b/src/__tests__/backup.test.ts
@@ -201,21 +201,27 @@ describe("backup service", () => {
       );
     });
 
-    test("old backup missing 'attachments' is backfilled and accepted", () => {
-      // Old backups without 'attachments' should still pass — it's a known new-table key
+    test("old v1 backup with original 9 keys is backfilled and accepted", () => {
+      // The original v1 baseline had 9 keys; hospitals, doctors, medicalVisits, attachments came later
+      const v1BaselineKeys = [
+        "members", "insurers", "assets", "policies", "beneficiaries",
+        "payments", "cashValues", "coverageItems", "settings",
+      ];
       const data: Record<string, unknown[]> = {};
-      for (const key of ALL_TABLE_KEYS) {
-        if (key !== "attachments") data[key] = [];
-      }
+      for (const key of v1BaselineKeys) data[key] = [];
       const payload = { version: 1, data };
       expect(validateBackup(payload)).toBeNull();
-      // After validation, the missing key should be backfilled
-      expect((payload.data as Record<string, unknown>).attachments).toEqual([]);
+      // All later-added keys should be backfilled
+      const d = payload.data as Record<string, unknown>;
+      expect(d.hospitals).toEqual([]);
+      expect(d.doctors).toEqual([]);
+      expect(d.medicalVisits).toEqual([]);
+      expect(d.attachments).toEqual([]);
     });
 
     test("partial backup missing original v1 keys is rejected", () => {
-      // A payload with only 'attachments' and nothing else is corrupt — must be rejected
-      expect(validateBackup({ version: 1, data: { attachments: [] } })).toMatch(
+      // A payload with only later-added keys and nothing else is corrupt — must be rejected
+      expect(validateBackup({ version: 1, data: { attachments: [], hospitals: [] } })).toMatch(
         /Missing required table key/,
       );
     });

--- a/src/__tests__/e2e/backup.e2e.test.ts
+++ b/src/__tests__/e2e/backup.e2e.test.ts
@@ -13,6 +13,7 @@ interface BackupData {
     payments: unknown[];
     cashValues: unknown[];
     coverageItems: unknown[];
+    attachments: unknown[];
     settings: unknown[];
     hospitals: unknown[];
     doctors: unknown[];
@@ -29,6 +30,7 @@ const ALL_TABLE_KEYS = [
   "payments",
   "cashValues",
   "coverageItems",
+  "attachments",
   "settings",
   "hospitals",
   "doctors",
@@ -72,7 +74,7 @@ describe("Backup API E2E", () => {
     expect(new Date(backup.exportedAt).toISOString()).toBe(backup.exportedAt);
   });
 
-  test("response body contains all 12 table keys", async () => {
+  test("response body contains all 13 table keys", async () => {
     const response = await fetch(`${getBaseUrl()}/api/backup`);
     const backup: BackupData = await response.json();
 

--- a/src/db/backup.ts
+++ b/src/db/backup.ts
@@ -242,12 +242,20 @@ export function buildBackupFilename(): string {
 // ── Import ───────────────────────────────────────────────────────────
 
 /**
+ * Table keys that were added after the initial v1 backup format.
+ * Only these may be absent in older backups and will be backfilled with [].
+ * All original v1 keys are still required — a payload missing them is
+ * treated as corrupt/partial and rejected to prevent accidental data wipe.
+ */
+const BACKFILL_ALLOWED_KEYS: ReadonlySet<TableKey> = new Set(["attachments"]);
+
+/**
  * Validate that a parsed JSON object looks like a valid backup payload.
  * Returns an error message string if invalid, or null if valid.
  *
- * Missing table keys are automatically backfilled with empty arrays for
- * forward-compatibility (older backups won't have newer tables like attachments).
- * If a key is present, it must be an array.
+ * Keys listed in BACKFILL_ALLOWED_KEYS may be absent (backfilled with []).
+ * All other table keys are required — missing ones indicate a corrupt or
+ * partial backup that must not be fed into the destructive restore path.
  */
 export function validateBackup(payload: unknown): string | null {
   if (payload == null || typeof payload !== "object") {
@@ -263,10 +271,13 @@ export function validateBackup(payload: unknown): string | null {
   const data = obj.data as Record<string, unknown>;
   for (const key of ALL_TABLE_KEYS) {
     const val = data[key];
-    // Missing keys are backfilled with empty arrays (forward-compat for older backups)
     if (val === undefined || val === null) {
-      data[key] = [];
-      continue;
+      // Only backfill keys added after the initial v1 format
+      if (BACKFILL_ALLOWED_KEYS.has(key)) {
+        data[key] = [];
+        continue;
+      }
+      return `Missing required table key: data.${key}`;
     }
     if (!Array.isArray(val)) {
       return `data.${key} must be an array, got ${typeof val}`;

--- a/src/db/backup.ts
+++ b/src/db/backup.ts
@@ -34,6 +34,7 @@ export interface BackupData {
     payments: BackupRow[];
     cashValues: BackupRow[];
     coverageItems: BackupRow[];
+    attachments: BackupRow[];
     settings: BackupRow[];
     hospitals: BackupRow[];
     doctors: BackupRow[];
@@ -50,6 +51,7 @@ export interface RestoreCounts {
   payments: number;
   cashValues: number;
   coverageItems: number;
+  attachments: number;
   settings: number;
   hospitals: number;
   doctors: number;
@@ -66,6 +68,7 @@ export const ALL_TABLE_KEYS = [
   "payments",
   "cashValues",
   "coverageItems",
+  "attachments",
   "settings",
   "hospitals",
   "doctors",
@@ -87,6 +90,7 @@ const TABLE_NAME_MAP: Record<TableKey, string> = {
   payments: "payments",
   cashValues: "cash_values",
   coverageItems: "coverage_items",
+  attachments: "attachments",
   settings: "settings",
   hospitals: "hospitals",
   doctors: "doctors",
@@ -109,6 +113,7 @@ const SCHEMA_TABLE_MAP: Record<TableKey, any> = {
   payments: schema.payments,
   cashValues: schema.cashValues,
   coverageItems: schema.coverageItems,
+  attachments: schema.attachments,
   settings: schema.settings,
   hospitals: schema.hospitals,
   doctors: schema.doctors,
@@ -218,6 +223,7 @@ export async function buildBackup(db: DbInstance): Promise<BackupData> {
       payments: await queryTable("payments"),
       cashValues: await queryTable("cashValues"),
       coverageItems: await queryTable("coverageItems"),
+      attachments: await queryTable("attachments"),
       settings: await queryTable("settings"),
       hospitals: await queryTable("hospitals"),
       doctors: await queryTable("doctors"),
@@ -238,6 +244,9 @@ export function buildBackupFilename(): string {
 /**
  * Validate that a parsed JSON object looks like a valid backup payload.
  * Returns an error message string if invalid, or null if valid.
+ *
+ * For v1 backups, ALL table keys must be present (as arrays, even if empty).
+ * Partial backups are rejected to prevent data integrity issues during restore.
  */
 export function validateBackup(payload: unknown): string | null {
   if (payload == null || typeof payload !== "object") {
@@ -253,8 +262,11 @@ export function validateBackup(payload: unknown): string | null {
   const data = obj.data as Record<string, unknown>;
   for (const key of ALL_TABLE_KEYS) {
     const val = data[key];
-    // undefined/null is ok (treated as empty), but if present must be array
-    if (val !== undefined && val !== null && !Array.isArray(val)) {
+    // For v1 backups, require ALL table keys to be present as arrays
+    if (val === undefined || val === null) {
+      return `Missing required table key: data.${key}`;
+    }
+    if (!Array.isArray(val)) {
       return `data.${key} must be an array, got ${typeof val}`;
     }
   }
@@ -272,6 +284,7 @@ const DELETE_ORDER: readonly TableKey[] = [
   "cashValues",
   "payments",
   "beneficiaries",
+  "attachments",
   "policies",
   "assets",
   "insurers",
@@ -291,6 +304,7 @@ const INSERT_ORDER: readonly TableKey[] = [
   "payments",
   "cashValues",
   "coverageItems",
+  "attachments",
   "settings",
   "hospitals",
   "doctors",
@@ -388,6 +402,7 @@ export async function restoreBackup(
     payments: 0,
     cashValues: 0,
     coverageItems: 0,
+    attachments: 0,
     settings: 0,
     hospitals: 0,
     doctors: 0,
@@ -398,11 +413,14 @@ export async function restoreBackup(
     // D1 path: collect all statements and execute atomically via batch API
     const statements: SqlStatement[] = [];
 
-    // 1. Clear all tables (FK-safe order)
+    // 1. Clear tables that have data in the backup (FK-safe order)
+    // Only delete if the backup contains data for that table
     for (const key of DELETE_ORDER) {
-      statements.push({ sql: `DELETE FROM ${TABLE_NAME_MAP[key]}`, params: [] });
+      const rows = data[key];
+      if (rows && rows.length > 0) {
+        statements.push({ sql: `DELETE FROM ${TABLE_NAME_MAP[key]}`, params: [] });
+      }
     }
-    statements.push({ sql: "DELETE FROM sqlite_sequence", params: [] });
 
     // 2. Build INSERT statements (FK-safe order)
     for (const key of INSERT_ORDER) {
@@ -425,12 +443,15 @@ export async function restoreBackup(
     // bun-sqlite path: local transaction with Drizzle ORM insert
     await db.run(sql.raw("BEGIN TRANSACTION"));
     try {
-      // 1. Clear all tables (FK-safe order)
+      // 1. Clear tables that have data in the backup (FK-safe order)
+      // Only delete if the backup contains data for that table
       for (const key of DELETE_ORDER) {
-        const tableName = TABLE_NAME_MAP[key];
-        await db.run(sql.raw(`DELETE FROM ${tableName}`));
+        const rows = data[key];
+        if (rows && rows.length > 0) {
+          const tableName = TABLE_NAME_MAP[key];
+          await db.run(sql.raw(`DELETE FROM ${tableName}`));
+        }
       }
-      await db.run(sql.raw("DELETE FROM sqlite_sequence"));
 
       // 2. Insert rows via Drizzle ORM (FK-safe order)
       for (const key of INSERT_ORDER) {

--- a/src/db/backup.ts
+++ b/src/db/backup.ts
@@ -242,12 +242,22 @@ export function buildBackupFilename(): string {
 // ── Import ───────────────────────────────────────────────────────────
 
 /**
- * Table keys that were added after the initial v1 backup format.
+ * Table keys added after the stable v1 baseline (9 keys).
  * Only these may be absent in older backups and will be backfilled with [].
  * All original v1 keys are still required — a payload missing them is
  * treated as corrupt/partial and rejected to prevent accidental data wipe.
+ *
+ * History:
+ *   v1 baseline (9 keys): members, insurers, assets, policies, beneficiaries,
+ *                          payments, cashValues, coverageItems, settings
+ *   Later additions:       hospitals, doctors, medicalVisits, attachments
  */
-const BACKFILL_ALLOWED_KEYS: ReadonlySet<TableKey> = new Set(["attachments"]);
+const BACKFILL_ALLOWED_KEYS: ReadonlySet<TableKey> = new Set([
+  "hospitals",
+  "doctors",
+  "medicalVisits",
+  "attachments",
+]);
 
 /**
  * Validate that a parsed JSON object looks like a valid backup payload.

--- a/src/db/backup.ts
+++ b/src/db/backup.ts
@@ -245,8 +245,9 @@ export function buildBackupFilename(): string {
  * Validate that a parsed JSON object looks like a valid backup payload.
  * Returns an error message string if invalid, or null if valid.
  *
- * For v1 backups, ALL table keys must be present (as arrays, even if empty).
- * Partial backups are rejected to prevent data integrity issues during restore.
+ * Missing table keys are automatically backfilled with empty arrays for
+ * forward-compatibility (older backups won't have newer tables like attachments).
+ * If a key is present, it must be an array.
  */
 export function validateBackup(payload: unknown): string | null {
   if (payload == null || typeof payload !== "object") {
@@ -262,9 +263,10 @@ export function validateBackup(payload: unknown): string | null {
   const data = obj.data as Record<string, unknown>;
   for (const key of ALL_TABLE_KEYS) {
     const val = data[key];
-    // For v1 backups, require ALL table keys to be present as arrays
+    // Missing keys are backfilled with empty arrays (forward-compat for older backups)
     if (val === undefined || val === null) {
-      return `Missing required table key: data.${key}`;
+      data[key] = [];
+      continue;
     }
     if (!Array.isArray(val)) {
       return `data.${key} must be an array, got ${typeof val}`;
@@ -413,14 +415,11 @@ export async function restoreBackup(
     // D1 path: collect all statements and execute atomically via batch API
     const statements: SqlStatement[] = [];
 
-    // 1. Clear tables that have data in the backup (FK-safe order)
-    // Only delete if the backup contains data for that table
+    // 1. Clear all tables (FK-safe order) — full destructive replace
     for (const key of DELETE_ORDER) {
-      const rows = data[key];
-      if (rows && rows.length > 0) {
-        statements.push({ sql: `DELETE FROM ${TABLE_NAME_MAP[key]}`, params: [] });
-      }
+      statements.push({ sql: `DELETE FROM ${TABLE_NAME_MAP[key]}`, params: [] });
     }
+    statements.push({ sql: "DELETE FROM sqlite_sequence", params: [] });
 
     // 2. Build INSERT statements (FK-safe order)
     for (const key of INSERT_ORDER) {
@@ -443,15 +442,12 @@ export async function restoreBackup(
     // bun-sqlite path: local transaction with Drizzle ORM insert
     await db.run(sql.raw("BEGIN TRANSACTION"));
     try {
-      // 1. Clear tables that have data in the backup (FK-safe order)
-      // Only delete if the backup contains data for that table
+      // 1. Clear all tables (FK-safe order) — full destructive replace
       for (const key of DELETE_ORDER) {
-        const rows = data[key];
-        if (rows && rows.length > 0) {
-          const tableName = TABLE_NAME_MAP[key];
-          await db.run(sql.raw(`DELETE FROM ${tableName}`));
-        }
+        const tableName = TABLE_NAME_MAP[key];
+        await db.run(sql.raw(`DELETE FROM ${tableName}`));
       }
+      await db.run(sql.raw("DELETE FROM sqlite_sequence"));
 
       // 2. Insert rows via Drizzle ORM (FK-safe order)
       for (const key of INSERT_ORDER) {


### PR DESCRIPTION
Fixes #1

- Added attachments to all backup chain locations
- Strict validation: v1 backups must contain all table keys
- Restore no longer deletes data for tables missing in backup

**Review note**: Codex flagged old backup compatibility — consider adding migration path for pre-attachments backups.