### PR TITLE
fix(db): enforce request-level isolation and add upsert patterns

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -435,10 +435,12 @@ export function closeDb(): void {
 // ---------- Proxy for backward compatibility ----------
 
 /**
- * Dynamic db Proxy — routes to the correct database instance.
+ * Dynamic db Proxy — ONLY for use in tests.
  *
  * In test environment: uses in-memory SQLite.
- * In production: remote D1 via sqlite-proxy.
+ * Outside test environment: throws an error to enforce request-scoped DB access.
+ *
+ * Non-test code should use getDbForRequest() instead.
  */
 export const db = new Proxy({} as DbInstance, {
   get(_, prop) {
@@ -446,7 +448,9 @@ export const db = new Proxy({} as DbInstance, {
       if (!testDbInstance) createTestDb();
       return testDbInstance[prop];
     }
-    const remoteDb = createRemoteDb(resolveTargetDb());
-    return remoteDb[prop];
+    throw new Error(
+      "Global `db` proxy is only available in test environment. " +
+      "Use getDbForRequest() for request-scoped database access.",
+    );
   },
 });

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -328,6 +328,9 @@ export function initSchema(): void {
       value REAL NOT NULL
     );
 
+    -- Unique constraint: no duplicate policy_year per policy
+    CREATE UNIQUE INDEX IF NOT EXISTS unique_policy_year ON cash_values(policy_id, policy_year);
+
     CREATE TABLE IF NOT EXISTS coverage_items (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       policy_id INTEGER NOT NULL REFERENCES policies(id),

--- a/src/db/repositories/insurers.ts
+++ b/src/db/repositories/insurers.ts
@@ -21,9 +21,13 @@ export function createInsurersRepo(dbInstance: DbInstance) {
     },
 
     async findOrCreate(name: string): Promise<Insurer> {
-      const existing = await this.findByName(name);
-      if (existing) return existing;
-      return await this.create({ name });
+      return await dbInstance
+        .insert(insurers)
+        .values({ name })
+        .onConflictDoNothing({ target: insurers.name })
+        .returning()
+        .get()
+        ?? await this.findByName(name) as Insurer;
     },
 
     async update(id: number, data: Partial<NewInsurer>): Promise<Insurer | undefined> {

--- a/src/db/repositories/settings.ts
+++ b/src/db/repositories/settings.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { db, type DbInstance } from "../index";
 import { settings, type Setting } from "../schema";
 
@@ -14,22 +14,15 @@ export function createSettingsRepo(dbInstance: DbInstance) {
     },
 
     async set(key: string, value: string): Promise<Setting> {
-      const existing = await dbInstance
-        .select()
-        .from(settings)
-        .where(eq(settings.key, key))
+      return await dbInstance
+        .insert(settings)
+        .values({ key, value })
+        .onConflictDoUpdate({
+          target: settings.key,
+          set: { value, updatedAt: sql`(unixepoch())` },
+        })
+        .returning()
         .get();
-
-      if (existing) {
-        return await dbInstance
-          .update(settings)
-          .set({ value, updatedAt: new Date() })
-          .where(eq(settings.key, key))
-          .returning()
-          .get();
-      }
-
-      return await dbInstance.insert(settings).values({ key, value }).returning().get();
     },
 
     async delete(key: string): Promise<boolean> {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -195,14 +195,24 @@ export type NewPayment = typeof payments.$inferInsert;
 // ============================================================================
 // 7. cashValues - 现金价值
 // ============================================================================
-export const cashValues = sqliteTable("cash_values", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  policyId: integer("policy_id")
-    .notNull()
-    .references(() => policies.id),
-  policyYear: integer("policy_year").notNull(),
-  value: real("value").notNull(),
-});
+export const cashValues = sqliteTable(
+  "cash_values",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    policyId: integer("policy_id")
+      .notNull()
+      .references(() => policies.id),
+    policyYear: integer("policy_year").notNull(),
+    value: real("value").notNull(),
+  },
+  (table) => ({
+    // Ensure no duplicate policy_year per policy
+    uniquePolicyYear: unique("unique_policy_year").on(
+      table.policyId,
+      table.policyYear,
+    ),
+  }),
+);
 
 export type CashValue = typeof cashValues.$inferSelect;
 export type NewCashValue = typeof cashValues.$inferInsert;


### PR DESCRIPTION
Fixes #2

- Global db proxy now throws outside test environment
- Settings repo uses INSERT ON CONFLICT (upsert)
- Insurers findOrCreate uses upsert
- Added unique constraint on cash_values(policy_id, policy_year)

**Review note**: Codex identified MCP/backy still use singleton repos — needs follow-up to inject request-scoped repos.