### PR TITLE
fix(api): enforce insurer referential integrity in policy routes

### DIFF
--- a/src/app/api/policies/[id]/route.ts
+++ b/src/app/api/policies/[id]/route.ts
@@ -87,6 +87,11 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     insuredMemberId = null;
   }
 
+  // Resolve insurer: find or create by name, persist both insurerId and insurerName
+  const insurer = body.insurerName
+    ? await repos.insurers.findOrCreate(body.insurerName)
+    : null;
+
   const updated = await repos.policies.update(policyId, {
     applicantId: body.applicantId,
     insuredType: body.insuredType,
@@ -94,7 +99,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     insuredAssetId,
     category: body.category,
     subCategory: body.subCategory,
-    insurerName: body.insurerName,
+    ...(insurer && { insurerId: insurer.id, insurerName: insurer.name }),
     productName: body.productName,
     policyNumber: body.policyNumber,
     channel: body.channel,

--- a/src/app/api/policies/route.ts
+++ b/src/app/api/policies/route.ts
@@ -68,14 +68,29 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Resolve insurer: find or create by name, persist both insurerId and insurerName
+  const insurer = await repos.insurers.findOrCreate(body.insurerName);
+
+  // Server-side normalization: enforce insuredType mutual exclusion.
+  // When insuredType is "Member", clear insuredAssetId; when "Asset", clear insuredMemberId.
+  let insuredMemberId = body.insuredMemberId ?? null;
+  let insuredAssetId = body.insuredAssetId ?? null;
+  const insuredType = body.insuredType ?? "Member";
+  if (insuredType === "Member") {
+    insuredAssetId = null;
+  } else if (insuredType === "Asset") {
+    insuredMemberId = null;
+  }
+
   const policy = await repos.policies.create({
     applicantId: body.applicantId,
-    insuredType: body.insuredType ?? "Member",
-    insuredMemberId: body.insuredMemberId ?? null,
-    insuredAssetId: body.insuredAssetId ?? null,
+    insuredType,
+    insuredMemberId,
+    insuredAssetId,
     category: body.category,
     subCategory: body.subCategory ?? null,
-    insurerName: body.insurerName,
+    insurerId: insurer.id,
+    insurerName: insurer.name,
     productName: body.productName,
     policyNumber: body.policyNumber,
     channel: body.channel ?? null,


### PR DESCRIPTION
Fixes #3

- Policy create/update now persists both insurerId and insurerName
- Active-policy check on insurer delete uses insurerId
- Unified create/update insured-target validation

**Review note**: Codex identified insurer rename doesn't cascade to policies — follow-up needed.