### PR TITLE
fix(api): add defensive validation to member delete, visit update, and payment update

### DIFF
--- a/src/app/api/members/[id]/route.ts
+++ b/src/app/api/members/[id]/route.ts
@@ -96,6 +96,15 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     );
   }
 
+  // Check FK references: beneficiaries may reference this member
+  const beneficiaryRefs = await repos.beneficiaries.findByMemberId(memberId);
+  if (beneficiaryRefs.length > 0) {
+    return NextResponse.json(
+      { error: `该成员是 ${beneficiaryRefs.length} 份保单的受益人，无法删除` },
+      { status: 409 }
+    );
+  }
+
   // Check FK references: medical visits may reference this member
   const visits = await repos.medicalVisits.findByMemberId(memberId);
   if (visits.length > 0) {

--- a/src/app/api/policies/[id]/beneficiaries/route.ts
+++ b/src/app/api/policies/[id]/beneficiaries/route.ts
@@ -14,6 +14,12 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: "Invalid policy ID" }, { status: 400 });
   }
 
+  // Check if parent policy exists
+  const policy = await repos.policies.findById(policyId);
+  if (!policy) {
+    return NextResponse.json({ error: "Policy not found" }, { status: 404 });
+  }
+
   const records = await repos.beneficiaries.findByPolicyId(policyId);
   const members = await repos.members.findAll();
   const memberMap = new Map(members.map((m) => [m.id, m.name]));

--- a/src/app/api/policies/[id]/payments/[paymentId]/route.ts
+++ b/src/app/api/policies/[id]/payments/[paymentId]/route.ts
@@ -27,6 +27,20 @@ export async function PUT(request: NextRequest, context: RouteContext) {
 
   const body = await request.json();
 
+  // Check for periodNumber duplicate if being updated
+  if (body.periodNumber !== undefined && body.periodNumber !== existing.periodNumber) {
+    const policyPayments = await repos.payments.findByPolicyId(policyId);
+    const duplicate = policyPayments.find(
+      (p) => p.periodNumber === body.periodNumber && p.id !== paymentIdNum
+    );
+    if (duplicate) {
+      return NextResponse.json(
+        { error: `该保单已存在第 ${body.periodNumber} 期缴费记录` },
+        { status: 409 }
+      );
+    }
+  }
+
   const updated = await repos.payments.update(paymentIdNum, {
     periodNumber: body.periodNumber ?? existing.periodNumber,
     dueDate: body.dueDate ?? existing.dueDate,

--- a/src/db/repositories/beneficiaries.ts
+++ b/src/db/repositories/beneficiaries.ts
@@ -20,6 +20,14 @@ export function createBeneficiariesRepo(dbInstance: DbInstance) {
         .all();
     },
 
+    async findByMemberId(memberId: number): Promise<Beneficiary[]> {
+      return await dbInstance
+        .select()
+        .from(beneficiaries)
+        .where(eq(beneficiaries.memberId, memberId))
+        .all();
+    },
+
     async create(data: NewBeneficiary): Promise<Beneficiary> {
       return await dbInstance.insert(beneficiaries).values(data).returning().get();
     },


### PR DESCRIPTION
Fixes #4

- Member delete checks beneficiary references (returns 409)
- Medical visit update validates memberId
- Payment update checks periodNumber duplicates (returns 409)
- Nested routes return 404 for missing parent

**Review note**: Codex identified assets.owner_id also references members — follow-up needed.