### PR TITLE
fix(web): add error handling to CRUD list pages and delete dialogs

### DIFF
--- a/src/app/doctors/page.tsx
+++ b/src/app/doctors/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { Plus, Pencil, Trash2, Phone, Building2, Stethoscope } from "lucide-react";
+import { Plus, Pencil, Trash2, Phone, Building2, Stethoscope, AlertCircle } from "lucide-react";
 import { AppShell } from "@/components/layout";
 import { TablePageSkeleton } from "@/components/skeletons";
 import { Button } from "@/components/ui/button";
@@ -61,6 +61,8 @@ export default function DoctorsPage() {
   const [doctors, setDoctors] = useState<Doctor[]>([]);
   const [hospitals, setHospitals] = useState<Hospital[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editingDoctor, setEditingDoctor] = useState<Doctor | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -74,8 +76,14 @@ export default function DoctorsPage() {
 
   const fetchData = () => {
     Promise.all([
-      fetch("/api/doctors").then((res) => res.json()),
-      fetch("/api/hospitals").then((res) => res.json()),
+      fetch("/api/doctors").then((res) => {
+        if (!res.ok) throw new Error("FETCH_FAILED");
+        return res.json();
+      }),
+      fetch("/api/hospitals").then((res) => {
+        if (!res.ok) throw new Error("FETCH_FAILED");
+        return res.json();
+      }),
     ])
       .then(([doctorsData, hospitalsData]: [Doctor[], Hospital[]]) => {
         // Enrich doctors with hospital names
@@ -86,9 +94,13 @@ export default function DoctorsPage() {
         }));
         setDoctors(enrichedDoctors);
         setHospitals(hospitalsData);
+        setError(null);
         setLoading(false);
       })
-      .catch(() => setLoading(false));
+      .catch(() => {
+        setError("加载医生列表失败，请刷新页面重试");
+        setLoading(false);
+      });
   };
 
   useEffect(() => {
@@ -113,21 +125,36 @@ export default function DoctorsPage() {
   const handleDeleteConfirm = async () => {
     if (!doctorToDelete) return;
 
+    setDeleteError(null);
     const response = await fetch(`/api/doctors/${doctorToDelete.id}`, {
       method: "DELETE",
     });
 
     if (response.ok) {
+      setDeleteDialogOpen(false);
+      setDoctorToDelete(null);
       fetchData();
+    } else {
+      setDeleteError("删除医生失败，请重试");
     }
-    setDeleteDialogOpen(false);
-    setDoctorToDelete(null);
   };
 
   if (loading) {
     return (
       <AppShell breadcrumbs={[{ label: "医生管理" }]}>
         <TablePageSkeleton />
+      </AppShell>
+    );
+  }
+
+  if (error) {
+    return (
+      <AppShell breadcrumbs={[{ label: "医生管理" }]}>
+        <div className="rounded-card bg-secondary p-8 text-center">
+          <AlertCircle className="mx-auto h-12 w-12 text-destructive/50" />
+          <h3 className="mt-4 text-lg font-medium">加载失败</h3>
+          <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+        </div>
       </AppShell>
     );
   }
@@ -324,7 +351,10 @@ export default function DoctorsPage() {
         onSuccess={fetchData}
       />
 
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+      <AlertDialog open={deleteDialogOpen} onOpenChange={(open) => {
+        setDeleteDialogOpen(open);
+        if (!open) setDeleteError(null);
+      }}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>确认删除</AlertDialogTitle>
@@ -332,6 +362,12 @@ export default function DoctorsPage() {
               确定要删除医生「{doctorToDelete?.name}」吗？此操作无法撤销。
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {deleteError && (
+            <div className="flex items-center gap-2 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4" />
+              <span>{deleteError}</span>
+            </div>
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel>取消</AlertDialogCancel>
             <AlertDialogAction

--- a/src/app/hospitals/page.tsx
+++ b/src/app/hospitals/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { Plus, Pencil, Trash2, Phone, MapPin, Users } from "lucide-react";
+import { Plus, Pencil, Trash2, Phone, MapPin, Users, AlertCircle } from "lucide-react";
 import { AppShell } from "@/components/layout";
 import { TablePageSkeleton } from "@/components/skeletons";
 import { Button } from "@/components/ui/button";
@@ -55,6 +55,8 @@ interface Hospital {
 export default function HospitalsPage() {
   const [hospitals, setHospitals] = useState<Hospital[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editingHospital, setEditingHospital] = useState<Hospital | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -75,12 +77,19 @@ export default function HospitalsPage() {
 
   const fetchHospitals = () => {
     fetch("/api/hospitals")
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error("FETCH_FAILED");
+        return res.json();
+      })
       .then((data: Hospital[]) => {
         setHospitals(data);
+        setError(null);
         setLoading(false);
       })
-      .catch(() => setLoading(false));
+      .catch(() => {
+        setError("加载医院列表失败，请刷新页面重试");
+        setLoading(false);
+      });
   };
 
   useEffect(() => {
@@ -105,21 +114,36 @@ export default function HospitalsPage() {
   const handleDeleteConfirm = async () => {
     if (!hospitalToDelete) return;
 
+    setDeleteError(null);
     const response = await fetch(`/api/hospitals/${hospitalToDelete.id}`, {
       method: "DELETE",
     });
 
     if (response.ok) {
+      setDeleteDialogOpen(false);
+      setHospitalToDelete(null);
       fetchHospitals();
+    } else {
+      setDeleteError("删除医院失败，请重试");
     }
-    setDeleteDialogOpen(false);
-    setHospitalToDelete(null);
   };
 
   if (loading) {
     return (
       <AppShell breadcrumbs={[{ label: "医院管理" }]}>
         <TablePageSkeleton />
+      </AppShell>
+    );
+  }
+
+  if (error) {
+    return (
+      <AppShell breadcrumbs={[{ label: "医院管理" }]}>
+        <div className="rounded-card bg-secondary p-8 text-center">
+          <AlertCircle className="mx-auto h-12 w-12 text-destructive/50" />
+          <h3 className="mt-4 text-lg font-medium">加载失败</h3>
+          <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+        </div>
       </AppShell>
     );
   }
@@ -310,7 +334,10 @@ export default function HospitalsPage() {
         onSuccess={fetchHospitals}
       />
 
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+      <AlertDialog open={deleteDialogOpen} onOpenChange={(open) => {
+        setDeleteDialogOpen(open);
+        if (!open) setDeleteError(null);
+      }}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>确认删除</AlertDialogTitle>
@@ -318,6 +345,12 @@ export default function HospitalsPage() {
               确定要删除医院「{hospitalToDelete?.name}」吗？此操作无法撤销。
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {deleteError && (
+            <div className="flex items-center gap-2 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4" />
+              <span>{deleteError}</span>
+            </div>
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel>取消</AlertDialogCancel>
             <AlertDialogAction

--- a/src/app/medical-visits/page.tsx
+++ b/src/app/medical-visits/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { Plus, Pencil, Trash2, Building2, UserRound, Calendar, Clock } from "lucide-react";
+import { Plus, Pencil, Trash2, Building2, UserRound, Calendar, Clock, AlertCircle } from "lucide-react";
 import { AppShell } from "@/components/layout";
 import { TablePageSkeleton } from "@/components/skeletons";
 import { Button } from "@/components/ui/button";
@@ -159,6 +159,8 @@ export default function MedicalVisitsPage() {
   const [hospitals, setHospitals] = useState<Hospital[]>([]);
   const [doctors, setDoctors] = useState<Doctor[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editingVisit, setEditingVisit] = useState<MedicalVisit | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -167,10 +169,22 @@ export default function MedicalVisitsPage() {
 
   const fetchData = () => {
     Promise.all([
-      fetch("/api/medical-visits").then((res) => res.json()),
-      fetch("/api/members").then((res) => res.json()),
-      fetch("/api/hospitals").then((res) => res.json()),
-      fetch("/api/doctors").then((res) => res.json()),
+      fetch("/api/medical-visits").then((res) => {
+        if (!res.ok) throw new Error("FETCH_FAILED");
+        return res.json();
+      }),
+      fetch("/api/members").then((res) => {
+        if (!res.ok) throw new Error("FETCH_FAILED");
+        return res.json();
+      }),
+      fetch("/api/hospitals").then((res) => {
+        if (!res.ok) throw new Error("FETCH_FAILED");
+        return res.json();
+      }),
+      fetch("/api/doctors").then((res) => {
+        if (!res.ok) throw new Error("FETCH_FAILED");
+        return res.json();
+      }),
     ])
       .then(([visitsData, membersData, hospitalsData, doctorsData]: [MedicalVisit[], Member[], Hospital[], Doctor[]]) => {
         const memberMap = new Map(membersData.map((m) => [m.id, m]));
@@ -192,9 +206,13 @@ export default function MedicalVisitsPage() {
         setMembers(membersData);
         setHospitals(hospitalsData);
         setDoctors(doctorsData);
+        setError(null);
         setLoading(false);
       })
-      .catch(() => setLoading(false));
+      .catch(() => {
+        setError("加载就诊记录失败，请刷新页面重试");
+        setLoading(false);
+      });
   };
 
   useEffect(() => {
@@ -224,15 +242,18 @@ export default function MedicalVisitsPage() {
   const handleDeleteConfirm = async () => {
     if (!visitToDelete) return;
 
+    setDeleteError(null);
     const response = await fetch(`/api/medical-visits/${visitToDelete.id}`, {
       method: "DELETE",
     });
 
     if (response.ok) {
+      setDeleteDialogOpen(false);
+      setVisitToDelete(null);
       fetchData();
+    } else {
+      setDeleteError("删除就诊记录失败，请重试");
     }
-    setDeleteDialogOpen(false);
-    setVisitToDelete(null);
   };
 
   const canAddVisit = members.length > 0 && hospitals.length > 0;
@@ -241,6 +262,18 @@ export default function MedicalVisitsPage() {
     return (
       <AppShell breadcrumbs={[{ label: "就诊记录" }]}>
         <TablePageSkeleton />
+      </AppShell>
+    );
+  }
+
+  if (error) {
+    return (
+      <AppShell breadcrumbs={[{ label: "就诊记录" }]}>
+        <div className="rounded-card bg-secondary p-8 text-center">
+          <AlertCircle className="mx-auto h-12 w-12 text-destructive/50" />
+          <h3 className="mt-4 text-lg font-medium">加载失败</h3>
+          <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+        </div>
       </AppShell>
     );
   }
@@ -467,7 +500,10 @@ export default function MedicalVisitsPage() {
         onSuccess={fetchData}
       />
 
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+      <AlertDialog open={deleteDialogOpen} onOpenChange={(open) => {
+        setDeleteDialogOpen(open);
+        if (!open) setDeleteError(null);
+      }}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>确认删除</AlertDialogTitle>
@@ -475,6 +511,12 @@ export default function MedicalVisitsPage() {
               确定要删除「{visitToDelete?.memberName}」在 {visitToDelete?.visitDate} 的就诊记录吗？此操作无法撤销。
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {deleteError && (
+            <div className="flex items-center gap-2 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4" />
+              <span>{deleteError}</span>
+            </div>
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel>取消</AlertDialogCancel>
             <AlertDialogAction

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Plus, Pencil, Trash2, Shield } from "lucide-react";
+import { Plus, Pencil, Trash2, Shield, AlertCircle, Users } from "lucide-react";
 import { AppShell } from "@/components/layout";
 import { TablePageSkeleton } from "@/components/skeletons";
 import { Button } from "@/components/ui/button";
@@ -77,6 +77,8 @@ function calculateAge(birthDate: string | null): number | null {
 export default function MembersPage() {
   const [members, setMembers] = useState<Member[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editingMember, setEditingMember] = useState<Member | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -84,12 +86,19 @@ export default function MembersPage() {
 
   const fetchMembers = () => {
     fetch("/api/members")
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error("FETCH_FAILED");
+        return res.json();
+      })
       .then((data: Member[]) => {
         setMembers(data);
+        setError(null);
         setLoading(false);
       })
-      .catch(() => setLoading(false));
+      .catch(() => {
+        setError("加载家庭成员失败，请刷新页面重试");
+        setLoading(false);
+      });
   };
 
   useEffect(() => {
@@ -114,21 +123,36 @@ export default function MembersPage() {
   const handleDeleteConfirm = async () => {
     if (!memberToDelete) return;
 
+    setDeleteError(null);
     const response = await fetch(`/api/members/${memberToDelete.id}`, {
       method: "DELETE",
     });
 
     if (response.ok) {
+      setDeleteDialogOpen(false);
+      setMemberToDelete(null);
       fetchMembers();
+    } else {
+      setDeleteError("删除成员失败，请重试");
     }
-    setDeleteDialogOpen(false);
-    setMemberToDelete(null);
   };
 
   if (loading) {
     return (
       <AppShell breadcrumbs={[{ label: "家庭成员" }]}>
         <TablePageSkeleton />
+      </AppShell>
+    );
+  }
+
+  if (error) {
+    return (
+      <AppShell breadcrumbs={[{ label: "家庭成员" }]}>
+        <div className="rounded-card bg-secondary p-8 text-center">
+          <AlertCircle className="mx-auto h-12 w-12 text-destructive/50" />
+          <h3 className="mt-4 text-lg font-medium">加载失败</h3>
+          <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+        </div>
       </AppShell>
     );
   }
@@ -149,6 +173,15 @@ export default function MembersPage() {
           </Button>
         </div>
 
+        {members.length === 0 ? (
+          <div className="rounded-card bg-secondary p-8 text-center">
+            <Users className="mx-auto h-12 w-12 text-muted-foreground/50" />
+            <h3 className="mt-4 text-lg font-medium">暂无家庭成员</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              点击上方按钮添加您的第一位家庭成员
+            </p>
+          </div>
+        ) : (
         <div className="rounded-card bg-secondary">
           <Table>
             <TableHeader>
@@ -261,6 +294,7 @@ export default function MembersPage() {
             </TableBody>
           </Table>
         </div>
+        )}
       </div>
 
       <MemberSheet
@@ -270,7 +304,10 @@ export default function MembersPage() {
         onSuccess={fetchMembers}
       />
 
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+      <AlertDialog open={deleteDialogOpen} onOpenChange={(open) => {
+        setDeleteDialogOpen(open);
+        if (!open) setDeleteError(null);
+      }}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>确认删除</AlertDialogTitle>
@@ -278,6 +315,12 @@ export default function MembersPage() {
               确定要删除成员「{memberToDelete?.name}」吗？此操作无法撤销。
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {deleteError && (
+            <div className="flex items-center gap-2 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4" />
+              <span>{deleteError}</span>
+            </div>
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel>取消</AlertDialogCancel>
             <AlertDialogAction onClick={handleDeleteConfirm} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">

--- a/src/app/policies/page.tsx
+++ b/src/app/policies/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { usePersistedState } from "@/hooks/use-persisted-state";
-import { Trash2, Info, Check, List, LayoutGrid, Users, Plus, Paperclip, FileText, ImageIcon } from "lucide-react";
+import { Trash2, Info, Check, List, LayoutGrid, Users, Plus, Paperclip, FileText, ImageIcon, AlertCircle, Shield } from "lucide-react";
 import { AppShell } from "@/components/layout";
 import { TablePageSkeleton } from "@/components/skeletons";
 import { Button } from "@/components/ui/button";
@@ -205,6 +205,7 @@ export default function PoliciesPage() {
   const router = useRouter();
   const [policies, setPolicies] = useState<Policy[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<number | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [policyToDelete, setPolicyToDelete] = useState<Policy | null>(null);
@@ -231,12 +232,19 @@ export default function PoliciesPage() {
 
   const fetchPolicies = () => {
     fetch("/api/policies")
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error("FETCH_FAILED");
+        return res.json();
+      })
       .then((data: Policy[]) => {
         setPolicies(data);
+        setError(null);
         setLoading(false);
       })
-      .catch(() => setLoading(false));
+      .catch(() => {
+        setError("加载保单列表失败，请刷新页面重试");
+        setLoading(false);
+      });
   };
 
   useEffect(() => {
@@ -385,6 +393,8 @@ export default function PoliciesPage() {
       });
       if (response.ok) {
         setActionError(null);
+        setDeleteDialogOpen(false);
+        setPolicyToDelete(null);
         fetchPolicies();
       } else {
         throw new Error("DELETE_FAILED");
@@ -393,8 +403,6 @@ export default function PoliciesPage() {
       console.error("Error deleting policy:", error);
       setActionError("删除保单失败，请重试");
     }
-    setDeleteDialogOpen(false);
-    setPolicyToDelete(null);
   };
 
   const handleCopyPolicyNumber = async (policy: Policy) => {
@@ -441,6 +449,18 @@ export default function PoliciesPage() {
     return (
       <AppShell breadcrumbs={[{ label: "保单" }]}>
         <TablePageSkeleton rows={10} />
+      </AppShell>
+    );
+  }
+
+  if (error) {
+    return (
+      <AppShell breadcrumbs={[{ label: "保单" }]}>
+        <div className="rounded-card bg-secondary p-8 text-center">
+          <AlertCircle className="mx-auto h-12 w-12 text-destructive/50" />
+          <h3 className="mt-4 text-lg font-medium">加载失败</h3>
+          <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+        </div>
       </AppShell>
     );
   }
@@ -578,8 +598,19 @@ export default function PoliciesPage() {
           </ToggleGroup>
         </div>
 
+        {/* Empty State */}
+        {policies.length === 0 && (
+          <div className="rounded-card bg-secondary p-8 text-center">
+            <Shield className="mx-auto h-12 w-12 text-muted-foreground/50" />
+            <h3 className="mt-4 text-lg font-medium">暂无保单</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              点击上方按钮添加您的第一份保单
+            </p>
+          </div>
+        )}
+
         {/* List View */}
-        {viewMode === "list" && (
+        {viewMode === "list" && policies.length > 0 && (
           <>
             <div className="space-y-3 sm:hidden">
               {filteredPolicies.map((policy) => (
@@ -798,7 +829,7 @@ export default function PoliciesPage() {
         )}
 
         {/* Grouped Views */}
-        {(viewMode === "byCategory" || viewMode === "byInsured") && (
+        {(viewMode === "byCategory" || viewMode === "byInsured") && policies.length > 0 && (
           <div className="space-y-6">
             {(viewMode === "byCategory" ? policiesByCategory : policiesByInsured).map(([groupKey, groupPolicies]) => {
               const groupLabel = viewMode === "byCategory" 
@@ -903,7 +934,10 @@ export default function PoliciesPage() {
         )}
       </div>
 
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+      <AlertDialog open={deleteDialogOpen} onOpenChange={(open) => {
+        setDeleteDialogOpen(open);
+        if (!open) setActionError(null);
+      }}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>确认删除</AlertDialogTitle>
@@ -911,6 +945,12 @@ export default function PoliciesPage() {
               确定要删除保单「{policyToDelete?.productName}」吗？此操作无法撤销。
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {actionError && (
+            <div className="flex items-center gap-2 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4" />
+              <span>{actionError}</span>
+            </div>
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel>取消</AlertDialogCancel>
             <AlertDialogAction onClick={handleDeleteConfirm} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">


### PR DESCRIPTION
Fixes #5

- All list pages check res.ok, show error state on failure
- Delete dialogs stay open on backend failure with error feedback
- Added empty state to policies page

**Review note**: Codex suggested wrapping fetch in try/catch too — follow-up.