### PR TITLE
fix(web): policy detail — status handling, error feedback, and section improvements

### DIFF
--- a/src/components/attachments/attachment-section.tsx
+++ b/src/components/attachments/attachment-section.tsx
@@ -23,6 +23,7 @@ interface AttachmentSectionProps {
 export function AttachmentSection({ policyId }: AttachmentSectionProps) {
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [previewAttachment, setPreviewAttachment] = useState<Attachment | null>(
     null,
   );
@@ -32,14 +33,17 @@ export function AttachmentSection({ policyId }: AttachmentSectionProps) {
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const fetchAttachments = useCallback(async () => {
+    setLoadError(null);
     try {
       const res = await fetch(`/api/policies/${policyId}/attachments`);
       if (res.ok) {
         const data = (await res.json()) as Attachment[];
         setAttachments(data);
+      } else {
+        setLoadError(`加载附件失败 (${res.status})`);
       }
     } catch {
-      // Silently fail — user can retry by reloading
+      setLoadError("网络错误，无法加载附件");
     } finally {
       setLoading(false);
     }
@@ -92,6 +96,20 @@ export function AttachmentSection({ policyId }: AttachmentSectionProps) {
         <p className="text-sm text-muted-foreground text-center py-4">
           加载中...
         </p>
+      ) : loadError ? (
+        <div className="rounded-lg bg-destructive/10 p-4 text-center">
+          <p className="text-sm text-destructive">{loadError}</p>
+          <button
+            type="button"
+            onClick={() => {
+              setLoading(true);
+              fetchAttachments();
+            }}
+            className="mt-2 text-sm text-primary hover:underline"
+          >
+            点击重试
+          </button>
+        </div>
       ) : (
         <AttachmentList
           attachments={attachments}

--- a/src/components/policy-detail/coverage-section.tsx
+++ b/src/components/policy-detail/coverage-section.tsx
@@ -215,6 +215,7 @@ export function CoverageSection({
   const [editingForm, setEditingForm] = useState<CoverageFormData>(emptyForm);
   const [saving, setSaving] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<number | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const sorted = [...items].sort((a, b) => a.sortOrder - b.sortOrder);
 
@@ -233,19 +234,30 @@ export function CoverageSection({
   const handleAdd = async () => {
     if (!addingForm || !addingForm.name.trim()) return;
     setSaving(true);
+    setErrorMessage(null);
     try {
+      // Use max(sortOrder) + 1 instead of items.length for correct ordering
+      const maxSortOrder = items.length > 0
+        ? Math.max(...items.map(i => i.sortOrder))
+        : -1;
       const res = await fetch(`/api/policies/${policyId}/coverage-items`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(formToPayload(addingForm, items.length)),
+        body: JSON.stringify(formToPayload(addingForm, maxSortOrder + 1)),
       });
       if (res.ok) {
         const created = (await res.json()) as CoverageItem;
         onItemsChange([...items, created]);
         setAddingForm(null);
+      } else {
+        const err = await res.json().catch(() => null);
+        setErrorMessage(
+          (err as { error?: string } | null)?.error ??
+            `添加失败 (${res.status})`,
+        );
       }
-    } catch (e) {
-      console.error("Failed to add coverage item:", e);
+    } catch {
+      setErrorMessage("网络错误，请重试");
     } finally {
       setSaving(false);
     }
@@ -254,6 +266,7 @@ export function CoverageSection({
   const handleUpdate = async () => {
     if (editingId === null || !editingForm.name.trim()) return;
     setSaving(true);
+    setErrorMessage(null);
     try {
       const existing = items.find((i) => i.id === editingId);
       const res = await fetch(
@@ -270,15 +283,22 @@ export function CoverageSection({
         const updated = (await res.json()) as CoverageItem;
         onItemsChange(items.map((i) => (i.id === editingId ? updated : i)));
         setEditingId(null);
+      } else {
+        const err = await res.json().catch(() => null);
+        setErrorMessage(
+          (err as { error?: string } | null)?.error ??
+            `修改失败 (${res.status})`,
+        );
       }
-    } catch (e) {
-      console.error("Failed to update coverage item:", e);
+    } catch {
+      setErrorMessage("修改失败，请重试");
     } finally {
       setSaving(false);
     }
   };
 
   const handleDelete = async (itemId: number) => {
+    setErrorMessage(null);
     try {
       const res = await fetch(
         `/api/policies/${policyId}/coverage-items/${itemId}`,
@@ -286,9 +306,15 @@ export function CoverageSection({
       );
       if (res.ok) {
         onItemsChange(items.filter((i) => i.id !== itemId));
+      } else {
+        const err = await res.json().catch(() => null);
+        setErrorMessage(
+          (err as { error?: string } | null)?.error ??
+            `删除失败 (${res.status})`,
+        );
       }
-    } catch (e) {
-      console.error("Failed to delete coverage item:", e);
+    } catch {
+      setErrorMessage("删除失败，请重试");
     } finally {
       setDeleteTarget(null);
     }
@@ -318,6 +344,11 @@ export function CoverageSection({
           </Button>
         )}
       </div>
+
+      {/* Error message */}
+      {errorMessage && (
+        <p className="mb-2 text-sm text-destructive">{errorMessage}</p>
+      )}
 
       {/* Item list */}
       {sorted.length > 0 && (

--- a/src/components/policy-detail/editable-info-row.tsx
+++ b/src/components/policy-detail/editable-info-row.tsx
@@ -18,7 +18,7 @@ interface EditableInfoRowProps {
   type?: InputType;
   editValue?: string;
   onEditChange?: ((value: string) => void) | undefined;
-  options?: readonly { value: string; label: string }[];
+  options?: readonly { value: string; label: string; disabled?: boolean }[];
 }
 
 export function EditableInfoRow({
@@ -49,7 +49,7 @@ export function EditableInfoRow({
             </SelectTrigger>
             <SelectContent>
               {options.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
+                <SelectItem key={opt.value} value={opt.value} disabled={opt.disabled ?? false}>
                   {opt.label}
                 </SelectItem>
               ))}

--- a/src/components/policy-detail/meta-column.tsx
+++ b/src/components/policy-detail/meta-column.tsx
@@ -16,7 +16,7 @@ import {
   paymentFrequencyLabels,
   renewalTypeLabels,
 } from "@/lib/constants/policy";
-import type { PolicyDetail, Beneficiary } from "@/lib/types/policy";
+import type { PolicyDetail, Beneficiary, PolicyStatus } from "@/lib/types/policy";
 import { formatDateWithDays } from "@/lib/date-utils";
 import { EditableInfoRow } from "./editable-info-row";
 
@@ -49,12 +49,23 @@ const renewalTypes = [
   { value: "Yearly", label: "一年期" },
 ] as const;
 
+// DB-persisted statuses (Expired is derived, not directly settable)
 const statuses = [
   { value: "Active", label: "生效中" },
   { value: "Lapsed", label: "已失效" },
   { value: "Surrendered", label: "已退保" },
   { value: "Claimed", label: "已理赔" },
 ] as const;
+
+// Persistable status type (excludes Expired which is derived)
+type PersistableStatus = "Active" | "Lapsed" | "Surrendered" | "Claimed";
+
+// Map display status to the appropriate form status for editing
+// Expired maps to Active (the source status before expiry was derived)
+function toEditableStatus(status: PolicyStatus): PersistableStatus {
+  if (status === "Expired") return "Active";
+  return status;
+}
 
 function PersonRow({
   name,
@@ -97,7 +108,7 @@ function BasicInfoSection({
     category: string;
     subCategory: string;
     channel: string;
-    status: typeof policy.status;
+    status: PersistableStatus;
   };
 
   const [isEditing, setIsEditing] = useState(false);
@@ -110,7 +121,7 @@ function BasicInfoSection({
     category: policy.category,
     subCategory: policy.subCategory ?? "",
     channel: policy.channel ?? "",
-    status: policy.status,
+    status: toEditableStatus(policy.status),
   });
 
   const updateField = <K extends keyof FormData>(field: K, value: FormData[K]) => {
@@ -156,7 +167,7 @@ function BasicInfoSection({
       category: policy.category,
       subCategory: policy.subCategory ?? "",
       channel: policy.channel ?? "",
-      status: policy.status,
+      status: toEditableStatus(policy.status),
     });
     setIsEditing(false);
     setError(null);
@@ -249,7 +260,7 @@ function BasicInfoSection({
           type="select"
           options={statuses}
           editValue={formData.status}
-          onEditChange={isEditing ? (v) => updateField("status", v as typeof policy.status) : undefined}
+          onEditChange={isEditing ? (v) => updateField("status", v as PersistableStatus) : undefined}
         />
       </div>
       {error && <p className="text-xs text-destructive mt-2">{error}</p>}
@@ -799,9 +810,11 @@ function PersonInfoSection({
   ];
   const assetOptions = assets.map((a) => ({ value: String(a.id), label: a.name }));
 
+  // Disable Asset option when no assets exist
+  const hasAssets = assets.length > 0;
   const insuredTypeOptions = [
     { value: "Member", label: "人" },
-    { value: "Asset", label: "财产" },
+    { value: "Asset", label: hasAssets ? "财产" : "财产 (无可选资产)", disabled: !hasAssets },
   ];
 
   return (

--- a/src/components/policy-detail/payments-section.tsx
+++ b/src/components/policy-detail/payments-section.tsx
@@ -39,8 +39,10 @@ interface PaymentFormData {
   periodNumber: string;
   dueDate: string;
   amount: string;
-  status: "Pending" | "Paid";
+  status: "Pending" | "Paid" | "Overdue";
   paidDate: string;
+  // Track the original status to preserve Overdue when editing
+  originalStatus: "Pending" | "Paid" | "Overdue" | undefined;
 }
 
 const today = () => todayStr();
@@ -51,6 +53,7 @@ const emptyPaymentForm: PaymentFormData = {
   amount: "",
   status: "Pending",
   paidDate: today(),
+  originalStatus: undefined,
 };
 
 function paymentToForm(p: Payment): PaymentFormData {
@@ -58,8 +61,11 @@ function paymentToForm(p: Payment): PaymentFormData {
     periodNumber: String(p.periodNumber),
     dueDate: p.dueDate,
     amount: String(p.amount),
+    // Keep original status for display, but map to Pending for form interaction
+    // (UI only shows Pending/Paid options, but we preserve Overdue when submitting)
     status: p.status === "Overdue" ? "Pending" : p.status,
     paidDate: p.paidDate ?? today(),
+    originalStatus: p.status,
   };
 }
 
@@ -281,11 +287,20 @@ export function PaymentsSection({
     setSaving(true);
     setResultMessage(null);
     try {
+      // Determine the status to submit:
+      // - If user changed to Paid, use Paid
+      // - If user kept as Pending but original was Overdue, preserve Overdue
+      // - Otherwise use the form status
+      let submitStatus: "Pending" | "Paid" | "Overdue" = editingForm.status;
+      if (editingForm.status === "Pending" && editingForm.originalStatus === "Overdue") {
+        submitStatus = "Overdue";
+      }
+
       const body: Record<string, unknown> = {
         periodNumber: Number(editingForm.periodNumber),
         dueDate: editingForm.dueDate,
         amount: Number(editingForm.amount),
-        status: editingForm.status,
+        status: submitStatus,
       };
       if (editingForm.status === "Paid") {
         body.paidDate = editingForm.paidDate || today();
@@ -343,6 +358,12 @@ export function PaymentsSection({
         onPaymentsChange(
           payments.map((p) => (p.id === payment.id ? updated : p)),
         );
+      } else {
+        const err = await res.json().catch(() => null);
+        setResultMessage(
+          (err as { error?: string } | null)?.error ??
+            `标记失败 (${res.status})`,
+        );
       }
     } catch {
       setResultMessage("标记失败，请重试");
@@ -360,6 +381,12 @@ export function PaymentsSection({
       );
       if (res.ok) {
         onPaymentsChange(payments.filter((p) => p.id !== paymentId));
+      } else {
+        const err = await res.json().catch(() => null);
+        setResultMessage(
+          (err as { error?: string } | null)?.error ??
+            `删除失败 (${res.status})`,
+        );
       }
     } catch {
       setResultMessage("删除失败，请重试");


### PR DESCRIPTION
Fixes #8

- Expired status mapped back to source status before save
- Coverage items use max(sortOrder)+1
- All sections check response.ok with error feedback
- Attachment section shows error state

**Review note**: Codex noted Overdue status logic needs refinement — follow-up.