### PR TITLE
fix(mcp): JSON validation, shared utils, and date parsing fixes

### DIFF
--- a/mcp/__tests__/guard.test.ts
+++ b/mcp/__tests__/guard.test.ts
@@ -24,7 +24,7 @@ describe("checkMcpEnabled", () => {
     const result = await checkMcpEnabled();
     expect(result).toBeDefined();
     expect(result).toContain("MCP access is disabled");
-    expect(result).toContain("http://localhost:7012/settings");
+    expect(result).toContain("/settings");
   });
 
   test("should return error message when mcp.enabled is false", async () => {
@@ -62,6 +62,6 @@ describe("mcpDisabledResult", () => {
     const first = result.content[0] as { type: string; text: string };
     expect(first.type).toBe("text");
     expect(first.text).toContain("MCP access is disabled");
-    expect(first.text).toContain("http://localhost:7012/settings");
+    expect(first.text).toContain("/settings");
   });
 });

--- a/mcp/guard.ts
+++ b/mcp/guard.ts
@@ -14,7 +14,7 @@ import { settingsRepo } from "@/db/repositories";
 
 const DISABLED_MESSAGE = [
   "MCP access is disabled.",
-  "To enable it, open the Surety settings page at http://localhost:7012/settings",
+  "To enable it, open the Surety settings page at /settings",
   "and turn on the MCP Access toggle.",
 ].join(" ");
 

--- a/mcp/tools/assets.ts
+++ b/mcp/tools/assets.ts
@@ -8,16 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { assetsRepo, membersRepo, policiesRepo } from "@/db/repositories";
 import { checkMcpEnabled, mcpDisabledResult } from "../guard";
-
-/** Strip keys with undefined values (for exactOptionalPropertyTypes compat) */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function stripUndefined(obj: Record<string, unknown>): any {
-  const result: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(obj)) {
-    if (v !== undefined) result[k] = v;
-  }
-  return result;
-}
+import { stripUndefined, tryParseJson, validateJson } from "./shared";
 
 export function registerAssetTools(server: McpServer): void {
   server.tool(
@@ -38,7 +29,7 @@ export function registerAssetTools(server: McpServer): void {
             type: a.type,
             identifier: a.identifier,
             ownerName: owner?.name,
-            details: a.details ? JSON.parse(a.details) : undefined,
+            details: a.details ? tryParseJson(a.details) : undefined,
           };
         }),
       );
@@ -80,7 +71,7 @@ export function registerAssetTools(server: McpServer): void {
       const result = {
         ...asset,
         ownerName: owner?.name,
-        details: asset.details ? JSON.parse(asset.details) : undefined,
+        details: asset.details ? tryParseJson(asset.details) : undefined,
       };
 
       return {
@@ -113,6 +104,22 @@ export function registerAssetTools(server: McpServer): void {
       const error = await checkMcpEnabled();
       if (error) return mcpDisabledResult();
 
+      // Validate JSON format for details field
+      if (args.details !== undefined) {
+        const jsonError = validateJson(args.details);
+        if (jsonError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Invalid JSON in details field: ${jsonError}`,
+              },
+            ],
+          };
+        }
+      }
+
       const asset = await assetsRepo.create(stripUndefined(args));
 
       return {
@@ -138,6 +145,22 @@ export function registerAssetTools(server: McpServer): void {
     async ({ assetId, ...data }) => {
       const error = await checkMcpEnabled();
       if (error) return mcpDisabledResult();
+
+      // Validate JSON format for details field
+      if (data.details !== undefined) {
+        const jsonError = validateJson(data.details);
+        if (jsonError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Invalid JSON in details field: ${jsonError}`,
+              },
+            ],
+          };
+        }
+      }
 
       const updated = await assetsRepo.update(assetId, stripUndefined(data));
       if (!updated) {

--- a/mcp/tools/beneficiaries.ts
+++ b/mcp/tools/beneficiaries.ts
@@ -10,16 +10,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { beneficiariesRepo, policiesRepo, membersRepo } from "@/db/repositories";
 import { checkMcpEnabled, mcpDisabledResult } from "../guard";
-
-/** Strip keys with undefined values (for exactOptionalPropertyTypes compat) */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function stripUndefined(obj: Record<string, unknown>): any {
-  const result: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(obj)) {
-    if (v !== undefined) result[k] = v;
-  }
-  return result;
-}
+import { stripUndefined } from "./shared";
 
 export function registerBeneficiaryTools(server: McpServer): void {
   // -------------------------------------------------------------------------

--- a/mcp/tools/cash-values.ts
+++ b/mcp/tools/cash-values.ts
@@ -10,16 +10,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { cashValuesRepo, policiesRepo } from "@/db/repositories";
 import { checkMcpEnabled, mcpDisabledResult } from "../guard";
-
-/** Strip keys with undefined values (for exactOptionalPropertyTypes compat) */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function stripUndefined(obj: Record<string, unknown>): any {
-  const result: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(obj)) {
-    if (v !== undefined) result[k] = v;
-  }
-  return result;
-}
+import { stripUndefined } from "./shared";
 
 export function registerCashValueTools(server: McpServer): void {
   // -------------------------------------------------------------------------

--- a/mcp/tools/coverage-items.ts
+++ b/mcp/tools/coverage-items.ts
@@ -10,16 +10,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { coverageItemsRepo, policiesRepo } from "@/db/repositories";
 import { checkMcpEnabled, mcpDisabledResult } from "../guard";
-
-/** Strip keys with undefined values (for exactOptionalPropertyTypes compat) */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function stripUndefined(obj: Record<string, unknown>): any {
-  const result: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(obj)) {
-    if (v !== undefined) result[k] = v;
-  }
-  return result;
-}
+import { stripUndefined } from "./shared";
 
 export function registerCoverageItemTools(server: McpServer): void {
   // -------------------------------------------------------------------------

--- a/mcp/tools/coverage.ts
+++ b/mcp/tools/coverage.ts
@@ -13,6 +13,7 @@ import {
 } from "@/db/repositories";
 import { isEffectivelyActive, type PolicyDbStatus } from "@/db/types";
 import { checkMcpEnabled, mcpDisabledResult } from "../guard";
+import { parseLocalDate } from "./shared";
 
 export function registerCoverageTools(server: McpServer): void {
   // -------------------------------------------------------------------------
@@ -174,8 +175,8 @@ export function registerCoverageTools(server: McpServer): void {
           .filter((p) => {
             const dateStr = p.nextDueDate ?? p.expiryDate;
             if (!dateStr) return false;
-            const date = new Date(dateStr);
-            return date >= now && date <= cutoff;
+            const date = parseLocalDate(dateStr);
+            return date && date >= now && date <= cutoff;
           })
           .map(async (p) => {
             const applicant = await membersRepo.findById(p.applicantId);

--- a/mcp/tools/insurers.ts
+++ b/mcp/tools/insurers.ts
@@ -10,16 +10,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { insurersRepo, policiesRepo } from "@/db/repositories";
 import { checkMcpEnabled, mcpDisabledResult } from "../guard";
-
-/** Strip keys with undefined values (for exactOptionalPropertyTypes compat) */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function stripUndefined(obj: Record<string, unknown>): any {
-  const result: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(obj)) {
-    if (v !== undefined) result[k] = v;
-  }
-  return result;
-}
+import { stripUndefined } from "./shared";
 
 export function registerInsurerTools(server: McpServer): void {
   // -------------------------------------------------------------------------

--- a/mcp/tools/members.ts
+++ b/mcp/tools/members.ts
@@ -13,16 +13,7 @@ import {
   assetsRepo,
 } from "@/db/repositories";
 import { checkMcpEnabled, mcpDisabledResult } from "../guard";
-
-/** Strip keys with undefined values (for exactOptionalPropertyTypes compat) */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function stripUndefined(obj: Record<string, unknown>): any {
-  const result: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(obj)) {
-    if (v !== undefined) result[k] = v;
-  }
-  return result;
-}
+import { stripUndefined } from "./shared";
 
 export function registerMemberTools(server: McpServer): void {
   server.tool(

--- a/mcp/tools/payments.ts
+++ b/mcp/tools/payments.ts
@@ -10,16 +10,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { paymentsRepo, policiesRepo } from "@/db/repositories";
 import { checkMcpEnabled, mcpDisabledResult } from "../guard";
-
-/** Strip keys with undefined values (for exactOptionalPropertyTypes compat) */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function stripUndefined(obj: Record<string, unknown>): any {
-  const result: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(obj)) {
-    if (v !== undefined) result[k] = v;
-  }
-  return result;
-}
+import { stripUndefined } from "./shared";
 
 export function registerPaymentTools(server: McpServer): void {
   /**

--- a/mcp/tools/policies.ts
+++ b/mcp/tools/policies.ts
@@ -19,16 +19,7 @@ import {
 import { createBatchExecutor } from "@/db";
 import { deriveDisplayStatus, type PolicyDbStatus } from "@/db/types";
 import { checkMcpEnabled, mcpDisabledResult } from "../guard";
-
-/** Strip keys with undefined values (for exactOptionalPropertyTypes compat) */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function stripUndefined(obj: Record<string, unknown>): any {
-  const result: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(obj)) {
-    if (v !== undefined) result[k] = v;
-  }
-  return result;
-}
+import { stripUndefined } from "./shared";
 
 const policyCategories = [
   "Life",

--- a/mcp/tools/shared.ts
+++ b/mcp/tools/shared.ts
@@ -1,0 +1,53 @@
+/**
+ * MCP Tools: Shared Utilities
+ *
+ * Common utilities shared across all MCP tools.
+ */
+
+/** Strip keys with undefined values (for exactOptionalPropertyTypes compat) */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function stripUndefined(obj: Record<string, unknown>): any {
+  const result: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) result[k] = v;
+  }
+  return result;
+}
+
+/**
+ * Tolerant JSON parse — returns the parsed object on success,
+ * or the raw string on parse failure.
+ */
+export function tryParseJson(str: string): unknown {
+  try {
+    return JSON.parse(str);
+  } catch {
+    return str;
+  }
+}
+
+/**
+ * Validate that a string is valid JSON.
+ * Returns undefined if valid, or an error message string if invalid.
+ */
+export function validateJson(str: string): string | undefined {
+  try {
+    JSON.parse(str);
+    return undefined;
+  } catch (e) {
+    return e instanceof Error ? e.message : "Invalid JSON";
+  }
+}
+
+/**
+ * Parse a date string (YYYY-MM-DD) without UTC timezone shift.
+ * Uses explicit date component extraction to avoid timezone issues.
+ * Returns the Date at midnight local time, or null if invalid.
+ */
+export function parseLocalDate(dateStr: string): Date | null {
+  const match = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return null;
+  const [, year, month, day] = match;
+  // month is 0-indexed in Date constructor
+  return new Date(Number(year), Number(month) - 1, Number(day));
+}


### PR DESCRIPTION
Fixes #7

- Extracted stripUndefined() to shared module
- Assets details JSON validated on write, tolerant parse on read
- Guard URL uses relative path

**Review note**: Codex flagged parseLocalDate should match canonical parser — follow-up.