### PR TITLE
perf(db): add indexes, transactional seed, and lightweight deletes

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -406,6 +406,17 @@ export function initSchema(): void {
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
+
+    -- Performance indexes on foreign keys
+    CREATE INDEX IF NOT EXISTS idx_policies_insurer_id ON policies(insurer_id);
+    CREATE INDEX IF NOT EXISTS idx_policies_insured_member_id ON policies(insured_member_id);
+    CREATE INDEX IF NOT EXISTS idx_policies_insured_asset_id ON policies(insured_asset_id);
+    CREATE INDEX IF NOT EXISTS idx_beneficiaries_policy_id ON beneficiaries(policy_id);
+    CREATE INDEX IF NOT EXISTS idx_payments_policy_id ON payments(policy_id);
+    CREATE INDEX IF NOT EXISTS idx_coverage_items_policy_id ON coverage_items(policy_id);
+    CREATE INDEX IF NOT EXISTS idx_medical_visits_member_id ON medical_visits(member_id);
+    CREATE INDEX IF NOT EXISTS idx_medical_visits_hospital_id ON medical_visits(hospital_id);
+    CREATE INDEX IF NOT EXISTS idx_medical_visits_doctor_id ON medical_visits(doctor_id);
   `);
 }
 

--- a/src/db/repositories/assets.ts
+++ b/src/db/repositories/assets.ts
@@ -30,8 +30,8 @@ export function createAssetsRepo(dbInstance: DbInstance) {
     },
 
     async delete(id: number): Promise<boolean> {
-      const rows = await dbInstance.delete(assets).where(eq(assets.id, id)).returning().all();
-      return rows.length > 0;
+      const result = await dbInstance.delete(assets).where(eq(assets.id, id)).run();
+      return (result.changes ?? result.rowsAffected ?? 0) > 0;
     },
   };
 }

--- a/src/db/repositories/beneficiaries.ts
+++ b/src/db/repositories/beneficiaries.ts
@@ -34,17 +34,16 @@ export function createBeneficiariesRepo(dbInstance: DbInstance) {
     },
 
     async delete(id: number): Promise<boolean> {
-      const rows = await dbInstance.delete(beneficiaries).where(eq(beneficiaries.id, id)).returning().all();
-      return rows.length > 0;
+      const result = await dbInstance.delete(beneficiaries).where(eq(beneficiaries.id, id)).run();
+      return (result.changes ?? result.rowsAffected ?? 0) > 0;
     },
 
     async deleteByPolicyId(policyId: number): Promise<number> {
-      const rows = await dbInstance
+      const result = await dbInstance
         .delete(beneficiaries)
         .where(eq(beneficiaries.policyId, policyId))
-        .returning()
-        .all();
-      return rows.length;
+        .run();
+      return result.changes ?? result.rowsAffected ?? 0;
     },
   };
 }

--- a/src/db/repositories/cashValues.ts
+++ b/src/db/repositories/cashValues.ts
@@ -38,17 +38,16 @@ export function createCashValuesRepo(dbInstance: DbInstance) {
     },
 
     async delete(id: number): Promise<boolean> {
-      const rows = await dbInstance.delete(cashValues).where(eq(cashValues.id, id)).returning().all();
-      return rows.length > 0;
+      const result = await dbInstance.delete(cashValues).where(eq(cashValues.id, id)).run();
+      return (result.changes ?? result.rowsAffected ?? 0) > 0;
     },
 
     async deleteByPolicyId(policyId: number): Promise<number> {
-      const rows = await dbInstance
+      const result = await dbInstance
         .delete(cashValues)
         .where(eq(cashValues.policyId, policyId))
-        .returning()
-        .all();
-      return rows.length;
+        .run();
+      return result.changes ?? result.rowsAffected ?? 0;
     },
   };
 }

--- a/src/db/repositories/doctors.ts
+++ b/src/db/repositories/doctors.ts
@@ -34,8 +34,8 @@ export function createDoctorsRepo(dbInstance: DbInstance) {
     },
 
     async delete(id: number): Promise<boolean> {
-      const rows = await dbInstance.delete(doctors).where(eq(doctors.id, id)).returning().all();
-      return rows.length > 0;
+      const result = await dbInstance.delete(doctors).where(eq(doctors.id, id)).run();
+      return (result.changes ?? result.rowsAffected ?? 0) > 0;
     },
   };
 }

--- a/src/db/repositories/hospitals.ts
+++ b/src/db/repositories/hospitals.ts
@@ -31,8 +31,8 @@ export function createHospitalsRepo(dbInstance: DbInstance) {
     },
 
     async delete(id: number): Promise<boolean> {
-      const rows = await dbInstance.delete(hospitals).where(eq(hospitals.id, id)).returning().all();
-      return rows.length > 0;
+      const result = await dbInstance.delete(hospitals).where(eq(hospitals.id, id)).run();
+      return (result.changes ?? result.rowsAffected ?? 0) > 0;
     },
   };
 }

--- a/src/db/repositories/insurers.ts
+++ b/src/db/repositories/insurers.ts
@@ -36,8 +36,8 @@ export function createInsurersRepo(dbInstance: DbInstance) {
     },
 
     async delete(id: number): Promise<boolean> {
-      const rows = await dbInstance.delete(insurers).where(eq(insurers.id, id)).returning().all();
-      return rows.length > 0;
+      const result = await dbInstance.delete(insurers).where(eq(insurers.id, id)).run();
+      return (result.changes ?? result.rowsAffected ?? 0) > 0;
     },
   };
 }

--- a/src/db/repositories/members.ts
+++ b/src/db/repositories/members.ts
@@ -26,8 +26,8 @@ export function createMembersRepo(dbInstance: DbInstance) {
     },
 
     async delete(id: number): Promise<boolean> {
-      const rows = await dbInstance.delete(members).where(eq(members.id, id)).returning().all();
-      return rows.length > 0;
+      const result = await dbInstance.delete(members).where(eq(members.id, id)).run();
+      return (result.changes ?? result.rowsAffected ?? 0) > 0;
     },
   };
 }

--- a/src/db/repositories/payments.ts
+++ b/src/db/repositories/payments.ts
@@ -52,17 +52,16 @@ export function createPaymentsRepo(dbInstance: DbInstance) {
     },
 
     async delete(id: number): Promise<boolean> {
-      const rows = await dbInstance.delete(payments).where(eq(payments.id, id)).returning().all();
-      return rows.length > 0;
+      const result = await dbInstance.delete(payments).where(eq(payments.id, id)).run();
+      return (result.changes ?? result.rowsAffected ?? 0) > 0;
     },
 
     async deleteByPolicyId(policyId: number): Promise<number> {
-      const rows = await dbInstance
+      const result = await dbInstance
         .delete(payments)
         .where(eq(payments.policyId, policyId))
-        .returning()
-        .all();
-      return rows.length;
+        .run();
+      return result.changes ?? result.rowsAffected ?? 0;
     },
   };
 }

--- a/src/db/repositories/policies.ts
+++ b/src/db/repositories/policies.ts
@@ -46,8 +46,8 @@ export function createPoliciesRepo(dbInstance: DbInstance) {
     },
 
     async delete(id: number): Promise<boolean> {
-      const rows = await dbInstance.delete(policies).where(eq(policies.id, id)).returning().all();
-      return rows.length > 0;
+      const result = await dbInstance.delete(policies).where(eq(policies.id, id)).run();
+      return (result.changes ?? result.rowsAffected ?? 0) > 0;
     },
   };
 }

--- a/src/db/repositories/settings.ts
+++ b/src/db/repositories/settings.ts
@@ -33,8 +33,8 @@ export function createSettingsRepo(dbInstance: DbInstance) {
     },
 
     async delete(key: string): Promise<boolean> {
-      const rows = await dbInstance.delete(settings).where(eq(settings.key, key)).returning().all();
-      return rows.length > 0;
+      const result = await dbInstance.delete(settings).where(eq(settings.key, key)).run();
+      return (result.changes ?? result.rowsAffected ?? 0) > 0;
     },
 
     async getNumber(key: string): Promise<number | undefined> {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, real, unique } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real, unique, index } from "drizzle-orm/sqlite-core";
 
 // ============================================================================
 // 1. members - 家庭成员
@@ -70,75 +70,84 @@ export type NewAsset = typeof assets.$inferInsert;
 // ============================================================================
 // 4. policies - 保单
 // ============================================================================
-export const policies = sqliteTable("policies", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
+export const policies = sqliteTable(
+  "policies",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
 
-  // 角色关联
-  applicantId: integer("applicant_id")
-    .notNull()
-    .references(() => members.id),
-  insuredType: text("insured_type", { enum: ["Member", "Asset"] }).notNull(),
-  insuredMemberId: integer("insured_member_id").references(() => members.id),
-  insuredAssetId: integer("insured_asset_id").references(() => assets.id),
+    // 角色关联
+    applicantId: integer("applicant_id")
+      .notNull()
+      .references(() => members.id),
+    insuredType: text("insured_type", { enum: ["Member", "Asset"] }).notNull(),
+    insuredMemberId: integer("insured_member_id").references(() => members.id),
+    insuredAssetId: integer("insured_asset_id").references(() => assets.id),
 
-  // 产品信息
-  category: text("category", {
-    enum: [
-      "Life",
-      "CriticalIllness",
-      "Medical",
-      "Accident",
-      "Annuity",
-      "Property",
-    ],
-  }).notNull(),
-  subCategory: text("sub_category"), // 子类别: 综合意外险、百万医疗险等
-  insurerId: integer("insurer_id").references(() => insurers.id),
-  insurerName: text("insurer_name").notNull(), // 冗余字段，便于查询展示
-  productName: text("product_name").notNull(),
-  policyNumber: text("policy_number").notNull().unique(),
-  channel: text("channel"), // 渠道: 关哥说险、支付宝等
+    // 产品信息
+    category: text("category", {
+      enum: [
+        "Life",
+        "CriticalIllness",
+        "Medical",
+        "Accident",
+        "Annuity",
+        "Property",
+      ],
+    }).notNull(),
+    subCategory: text("sub_category"), // 子类别: 综合意外险、百万医疗险等
+    insurerId: integer("insurer_id").references(() => insurers.id),
+    insurerName: text("insurer_name").notNull(), // 冗余字段，便于查询展示
+    productName: text("product_name").notNull(),
+    policyNumber: text("policy_number").notNull().unique(),
+    channel: text("channel"), // 渠道: 关哥说险、支付宝等
 
-  // 保障信息
-  sumAssured: real("sum_assured").notNull(),
+    // 保障信息
+    sumAssured: real("sum_assured").notNull(),
 
-  // 缴费信息
-  premium: real("premium").notNull(),
-  paymentFrequency: text("payment_frequency", {
-    enum: ["Single", "Monthly", "Yearly"],
-  }).notNull(),
-  paymentYears: integer("payment_years"),
-  totalPayments: integer("total_payments"),
-  renewalType: text("renewal_type", { enum: ["Manual", "Auto", "Yearly"] }),
-  paymentAccount: text("payment_account"),
-  nextDueDate: text("next_due_date"),
+    // 缴费信息
+    premium: real("premium").notNull(),
+    paymentFrequency: text("payment_frequency", {
+      enum: ["Single", "Monthly", "Yearly"],
+    }).notNull(),
+    paymentYears: integer("payment_years"),
+    totalPayments: integer("total_payments"),
+    renewalType: text("renewal_type", { enum: ["Manual", "Auto", "Yearly"] }),
+    paymentAccount: text("payment_account"),
+    nextDueDate: text("next_due_date"),
 
-  // 时间维度
-  effectiveDate: text("effective_date").notNull(),
-  expiryDate: text("expiry_date"),
-  hesitationEndDate: text("hesitation_end_date"),
-  waitingDays: integer("waiting_days"),
-  guaranteedRenewalYears: integer("guaranteed_renewal_years"), // 保证续保期间（年）
+    // 时间维度
+    effectiveDate: text("effective_date").notNull(),
+    expiryDate: text("expiry_date"),
+    hesitationEndDate: text("hesitation_end_date"),
+    waitingDays: integer("waiting_days"),
+    guaranteedRenewalYears: integer("guaranteed_renewal_years"), // 保证续保期间（年）
 
-  // 状态
-  status: text("status", {
-    enum: ["Active", "Lapsed", "Surrendered", "Claimed"],
-  })
-    .notNull()
-    .default("Active"),
-  deathBenefit: text("death_benefit"),
-  archived: integer("archived", { mode: "boolean" }).default(false),
+    // 状态
+    status: text("status", {
+      enum: ["Active", "Lapsed", "Surrendered", "Claimed"],
+    })
+      .notNull()
+      .default("Active"),
+    deathBenefit: text("death_benefit"),
+    archived: integer("archived", { mode: "boolean" }).default(false),
 
-  // 附加
-  policyFilePath: text("policy_file_path"),
-  notes: text("notes"),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .notNull()
-    .$defaultFn(() => new Date()),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
-    .notNull()
-    .$defaultFn(() => new Date()),
-});
+    // 附加
+    policyFilePath: text("policy_file_path"),
+    notes: text("notes"),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => ({
+    // Performance indexes on foreign keys
+    insurerIdx: index("idx_policies_insurer_id").on(table.insurerId),
+    insuredMemberIdx: index("idx_policies_insured_member_id").on(table.insuredMemberId),
+    insuredAssetIdx: index("idx_policies_insured_asset_id").on(table.insuredAssetId),
+  }),
+);
 
 export type Policy = typeof policies.$inferSelect;
 export type NewPolicy = typeof policies.$inferInsert;
@@ -146,17 +155,24 @@ export type NewPolicy = typeof policies.$inferInsert;
 // ============================================================================
 // 5. beneficiaries - 受益人
 // ============================================================================
-export const beneficiaries = sqliteTable("beneficiaries", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  policyId: integer("policy_id")
-    .notNull()
-    .references(() => policies.id),
-  memberId: integer("member_id").references(() => members.id),
-  externalName: text("external_name"),
-  externalIdCard: text("external_id_card"),
-  sharePercent: real("share_percent").notNull(),
-  rankOrder: integer("rank_order").notNull(),
-});
+export const beneficiaries = sqliteTable(
+  "beneficiaries",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    policyId: integer("policy_id")
+      .notNull()
+      .references(() => policies.id),
+    memberId: integer("member_id").references(() => members.id),
+    externalName: text("external_name"),
+    externalIdCard: text("external_id_card"),
+    sharePercent: real("share_percent").notNull(),
+    rankOrder: integer("rank_order").notNull(),
+  },
+  (table) => ({
+    // Performance index on foreign key
+    policyIdx: index("idx_beneficiaries_policy_id").on(table.policyId),
+  }),
+);
 
 export type Beneficiary = typeof beneficiaries.$inferSelect;
 export type NewBeneficiary = typeof beneficiaries.$inferInsert;
@@ -186,6 +202,8 @@ export const payments = sqliteTable(
       table.policyId,
       table.periodNumber,
     ),
+    // Performance index on foreign key
+    policyIdx: index("idx_payments_policy_id").on(table.policyId),
   }),
 );
 
@@ -210,20 +228,27 @@ export type NewCashValue = typeof cashValues.$inferInsert;
 // ============================================================================
 // 8. coverageItems - 保障权益明细
 // ============================================================================
-export const coverageItems = sqliteTable("coverage_items", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  policyId: integer("policy_id")
-    .notNull()
-    .references(() => policies.id),
-  name: text("name").notNull(), // 保障项名称, e.g. "一般医疗保险金"
-  periodLimit: real("period_limit"), // 保险期间内赔付限额（元）
-  lifetimeLimit: real("lifetime_limit"), // 保证续保期间内赔付限额（元）
-  deductible: real("deductible"), // 免赔额
-  coveragePercent: real("coverage_percent"), // 赔付比例, e.g. 100
-  isOptional: integer("is_optional", { mode: "boolean" }).default(false),
-  notes: text("notes"),
-  sortOrder: integer("sort_order").notNull().default(0),
-});
+export const coverageItems = sqliteTable(
+  "coverage_items",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    policyId: integer("policy_id")
+      .notNull()
+      .references(() => policies.id),
+    name: text("name").notNull(), // 保障项名称, e.g. "一般医疗保险金"
+    periodLimit: real("period_limit"), // 保险期间内赔付限额（元）
+    lifetimeLimit: real("lifetime_limit"), // 保证续保期间内赔付限额（元）
+    deductible: real("deductible"), // 免赔额
+    coveragePercent: real("coverage_percent"), // 赔付比例, e.g. 100
+    isOptional: integer("is_optional", { mode: "boolean" }).default(false),
+    notes: text("notes"),
+    sortOrder: integer("sort_order").notNull().default(0),
+  },
+  (table) => ({
+    // Performance index on foreign key
+    policyIdx: index("idx_coverage_items_policy_id").on(table.policyId),
+  }),
+);
 
 export type CoverageItem = typeof coverageItems.$inferSelect;
 export type NewCoverageItem = typeof coverageItems.$inferInsert;
@@ -231,19 +256,26 @@ export type NewCoverageItem = typeof coverageItems.$inferInsert;
 // ============================================================================
 // 9. attachments - 保单附件 (PDF files stored in R2)
 // ============================================================================
-export const attachments = sqliteTable("attachments", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  policyId: integer("policy_id")
-    .notNull()
-    .references(() => policies.id),
-  filename: text("filename").notNull(), // original filename: "某某保单.pdf"
-  r2Key: text("r2_key").notNull().unique(), // R2 object key: "policies/42/uuid.pdf"
-  contentType: text("content_type").notNull(), // MIME type: "application/pdf"
-  size: integer("size").notNull(), // file size in bytes
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .notNull()
-    .$defaultFn(() => new Date()),
-});
+export const attachments = sqliteTable(
+  "attachments",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    policyId: integer("policy_id")
+      .notNull()
+      .references(() => policies.id),
+    filename: text("filename").notNull(), // original filename: "某某保单.pdf"
+    r2Key: text("r2_key").notNull().unique(), // R2 object key: "policies/42/uuid.pdf"
+    contentType: text("content_type").notNull(), // MIME type: "application/pdf"
+    size: integer("size").notNull(), // file size in bytes
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => ({
+    // Performance index on foreign key
+    policyIdx: index("idx_attachments_policy_id").on(table.policyId),
+  }),
+);
 
 export type Attachment = typeof attachments.$inferSelect;
 export type NewAttachment = typeof attachments.$inferInsert;
@@ -316,38 +348,47 @@ export type NewDoctor = typeof doctors.$inferInsert;
 // ============================================================================
 // 13. medicalVisits - 就诊记录
 // ============================================================================
-export const medicalVisits = sqliteTable("medical_visits", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  memberId: integer("member_id")
-    .notNull()
-    .references(() => members.id),
-  hospitalId: integer("hospital_id")
-    .notNull()
-    .references(() => hospitals.id),
-  doctorId: integer("doctor_id").references(() => doctors.id),
-  visitDate: text("visit_date").notNull(),
-  visitTimeStart: text("visit_time_start"),
-  visitTimeEnd: text("visit_time_end"),
-  visitType: text("visit_type", {
-    enum: ["儿保", "门诊", "急诊", "体检", "复查", "预约"],
-  }).notNull(),
-  visitReason: text("visit_reason").notNull(),
-  department: text("department"),
-  symptoms: text("symptoms"), // JSON array: ["便血", "喂养"]
-  diagnosis: text("diagnosis"),
-  assessment: text("assessment"),
-  treatment: text("treatment"),
-  totalCost: real("total_cost"),
-  insurancePaid: real("insurance_paid"),
-  selfPaid: real("self_paid"),
-  notes: text("notes"),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .notNull()
-    .$defaultFn(() => new Date()),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
-    .notNull()
-    .$defaultFn(() => new Date()),
-});
+export const medicalVisits = sqliteTable(
+  "medical_visits",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    memberId: integer("member_id")
+      .notNull()
+      .references(() => members.id),
+    hospitalId: integer("hospital_id")
+      .notNull()
+      .references(() => hospitals.id),
+    doctorId: integer("doctor_id").references(() => doctors.id),
+    visitDate: text("visit_date").notNull(),
+    visitTimeStart: text("visit_time_start"),
+    visitTimeEnd: text("visit_time_end"),
+    visitType: text("visit_type", {
+      enum: ["儿保", "门诊", "急诊", "体检", "复查", "预约"],
+    }).notNull(),
+    visitReason: text("visit_reason").notNull(),
+    department: text("department"),
+    symptoms: text("symptoms"), // JSON array: ["便血", "喂养"]
+    diagnosis: text("diagnosis"),
+    assessment: text("assessment"),
+    treatment: text("treatment"),
+    totalCost: real("total_cost"),
+    insurancePaid: real("insurance_paid"),
+    selfPaid: real("self_paid"),
+    notes: text("notes"),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => ({
+    // Performance indexes on foreign keys
+    memberIdx: index("idx_medical_visits_member_id").on(table.memberId),
+    hospitalIdx: index("idx_medical_visits_hospital_id").on(table.hospitalId),
+    doctorIdx: index("idx_medical_visits_doctor_id").on(table.doctorId),
+  }),
+);
 
 export type MedicalVisit = typeof medicalVisits.$inferSelect;
 export type NewMedicalVisit = typeof medicalVisits.$inferInsert;

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -11,6 +11,7 @@ import {
   settingsRepo,
   insurersRepo,
 } from "./repositories";
+import { db, type DbInstance } from "./index";
 
 // ============================================================================
 // Seed Data Definitions
@@ -229,6 +230,18 @@ export const policySeedData: PolicySeed[] = [
 // Helper Functions
 // ============================================================================
 
+/**
+ * Lookup helper that throws if the key is not found in the map.
+ * Prevents silently passing undefined to downstream inserts.
+ */
+function requireLookup<K, V>(map: Map<K, V>, key: K, label: string): V {
+  const value = map.get(key);
+  if (value === undefined) {
+    throw new Error(`${label} "${key}" not found in lookup map`);
+  }
+  return value;
+}
+
 // ============================================================================
 // Seed Function (reusable)
 // ============================================================================
@@ -246,8 +259,10 @@ export interface SeedResult {
  * @param repos - Optional repos instance. When omitted, uses global singletons
  *                (backward compat). Scripts should pass createAllRepos(db) to
  *                avoid the global db Proxy.
+ * @param dbInstance - Optional db instance for transaction support. When provided,
+ *                     all seed operations are wrapped in a transaction.
  */
-export async function seedDatabase(repos?: AllRepos): Promise<SeedResult> {
+export async function seedDatabase(repos?: AllRepos, dbInstance?: DbInstance): Promise<SeedResult> {
   const r = repos ?? {
     members: membersRepo,
     assets: assetsRepo,
@@ -259,98 +274,107 @@ export async function seedDatabase(repos?: AllRepos): Promise<SeedResult> {
     insurers: insurersRepo,
   };
 
-  // Seed members
-  const memberMap = new Map<string, number>();
-  for (const member of familyMembers) {
-    const created = await r.members.create(member);
-    memberMap.set(member.name, created.id);
-  }
+  // Use provided dbInstance or fallback to the global proxy
+  const dbToUse = dbInstance ?? db;
 
-  // Seed assets
-  const assetMap = new Map<string, number>();
-  for (const asset of familyAssets) {
-    const ownerId = memberMap.get(asset.ownerName);
-    const created = await r.assets.create({
-      type: asset.type,
-      name: asset.name,
-      identifier: asset.identifier,
-      ownerId,
-      details: asset.details,
-    });
-    assetMap.set(asset.identifier, created.id);
-  }
-
-  // Seed insurers (extract unique insurer names from policies)
-  const uniqueInsurers = [...new Set(policySeedData.map((s) => s.policy.insurerName))];
-  for (const name of uniqueInsurers) {
-    await r.insurers.findOrCreate(name);
-  }
-
-  // Seed policies with related data
-  for (const seed of policySeedData) {
-    const applicantId = memberMap.get(seed.applicantName);
-    if (applicantId === undefined) {
-      throw new Error(`Applicant "${seed.applicantName}" not found in memberMap`);
+  // Wrap all seed operations in a transaction
+  return await dbToUse.transaction(async () => {
+    // Seed members
+    const memberMap = new Map<string, number>();
+    for (const member of familyMembers) {
+      const created = await r.members.create(member);
+      memberMap.set(member.name, created.id);
     }
-    const insuredMemberId = seed.insuredName ? memberMap.get(seed.insuredName) : undefined;
-    const insuredAssetId = seed.insuredAssetIdentifier ? assetMap.get(seed.insuredAssetIdentifier) : undefined;
 
-    const policy = await r.policies.create({
-      ...seed.policy,
-      applicantId,
-      insuredMemberId,
-      insuredAssetId,
-    });
+    // Seed assets
+    const assetMap = new Map<string, number>();
+    for (const asset of familyAssets) {
+      const ownerId = requireLookup(memberMap, asset.ownerName, "Asset owner");
+      const created = await r.assets.create({
+        type: asset.type,
+        name: asset.name,
+        identifier: asset.identifier,
+        ownerId,
+        details: asset.details,
+      });
+      assetMap.set(asset.identifier, created.id);
+    }
 
-    // Beneficiaries
-    if (seed.beneficiaries) {
-      for (const b of seed.beneficiaries) {
-        const bene: NewBeneficiary = {
+    // Seed insurers (extract unique insurer names from policies)
+    const uniqueInsurers = [...new Set(policySeedData.map((s) => s.policy.insurerName))];
+    for (const name of uniqueInsurers) {
+      await r.insurers.findOrCreate(name);
+    }
+
+    // Seed policies with related data
+    for (const seed of policySeedData) {
+      const applicantId = requireLookup(memberMap, seed.applicantName, "Applicant");
+      const insuredMemberId = seed.insuredName
+        ? requireLookup(memberMap, seed.insuredName, "Insured member")
+        : undefined;
+      const insuredAssetId = seed.insuredAssetIdentifier
+        ? requireLookup(assetMap, seed.insuredAssetIdentifier, "Insured asset")
+        : undefined;
+
+      const policy = await r.policies.create({
+        ...seed.policy,
+        applicantId,
+        insuredMemberId,
+        insuredAssetId,
+      });
+
+      // Beneficiaries
+      if (seed.beneficiaries) {
+        for (const b of seed.beneficiaries) {
+          const bene: NewBeneficiary = {
+            policyId: policy.id,
+            memberId: b.memberName
+              ? requireLookup(memberMap, b.memberName, "Beneficiary member")
+              : undefined,
+            externalName: b.externalName,
+            sharePercent: b.sharePercent,
+            rankOrder: b.rankOrder,
+          };
+          await r.beneficiaries.create(bene);
+        }
+      }
+
+      // Payments
+      const paymentRecords = generatePaymentRecords(
+        {
           policyId: policy.id,
-          memberId: b.memberName ? memberMap.get(b.memberName) : undefined,
-          externalName: b.externalName,
-          sharePercent: b.sharePercent,
-          rankOrder: b.rankOrder,
-        };
-        await r.beneficiaries.create(bene);
+          effectiveDate: seed.policy.effectiveDate,
+          paymentFrequency: seed.policy.paymentFrequency,
+          totalPayments: seed.policy.totalPayments ?? null,
+          premium: seed.policy.premium,
+        },
+        null, // null = generate all periods (seed mode)
+        new Set(), // no existing records
+      );
+      if (paymentRecords.length > 0) {
+        await r.payments.createMany(paymentRecords);
+      }
+
+      // Cash values
+      if (seed.cashValueYears) {
+        const cvRecords = seed.cashValueYears.map((year, idx) => ({
+          policyId: policy.id,
+          policyYear: year,
+          value: Math.round(seed.policy.premium * (idx + 1) * 0.3),
+        }));
+        await r.cashValues.createMany(cvRecords);
       }
     }
 
-    // Payments
-    const paymentRecords = generatePaymentRecords(
-      {
-        policyId: policy.id,
-        effectiveDate: seed.policy.effectiveDate,
-        paymentFrequency: seed.policy.paymentFrequency,
-        totalPayments: seed.policy.totalPayments ?? null,
-        premium: seed.policy.premium,
-      },
-      null, // null = generate all periods (seed mode)
-      new Set(), // no existing records
-    );
-    if (paymentRecords.length > 0) {
-      await r.payments.createMany(paymentRecords);
-    }
+    // Seed settings
+    await r.settings.set("annualIncome", "600000");
+    await r.settings.setNumber("emergencyFundMonths", 6);
+    await r.settings.setJson("riskTolerance", { level: "moderate", description: "Balanced growth" });
 
-    // Cash values
-    if (seed.cashValueYears) {
-      const cvRecords = seed.cashValueYears.map((year, idx) => ({
-        policyId: policy.id,
-        policyYear: year,
-        value: Math.round(seed.policy.premium * (idx + 1) * 0.3),
-      }));
-      await r.cashValues.createMany(cvRecords);
-    }
-  }
-
-  // Seed settings
-  await r.settings.set("annualIncome", "600000");
-  await r.settings.setNumber("emergencyFundMonths", 6);
-  await r.settings.setJson("riskTolerance", { level: "moderate", description: "Balanced growth" });
-
-  return {
-    members: familyMembers.length,
-    assets: familyAssets.length,
-    policies: policySeedData.length,
-  };
+    return {
+      members: familyMembers.length,
+      assets: familyAssets.length,
+      policies: policySeedData.length,
+    };
+  });
 }


### PR DESCRIPTION
Fixes #10

- Added indexes on FK columns
- Seed data wrapped in transaction
- Seed lookups fail fast on missing references
- Delete operations use lightweight pattern

**Review note**: Surety uses drizzle-kit push (not migration files), so schema changes deploy via push.