### PR TITLE
chore: remove stale hono CVE ignores

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -5,71 +5,78 @@
 # Review and re-evaluate on the ignoreUntil date.
 
 # --- @modelcontextprotocol/sdk transitive deps ---
+# MCP SDK pins hono@4.11.8 and @hono/node-server@1.19.9 as overridden deps.
+# Direct hono is ^4.12.14 but the SDK's transitive copies remain vulnerable.
 
 [[IgnoredVulns]]
 id = "GHSA-wc8c-qw6v-h7f6"
 ignoreUntil = 2026-06-23
-reason = "Indirect: @hono/node-server via @modelcontextprotocol/sdk"
+reason = "Indirect: @hono/node-server@1.19.9 pinned by @modelcontextprotocol/sdk"
+
+[[IgnoredVulns]]
+id = "GHSA-92pp-h63x-v22m"
+ignoreUntil = 2026-06-23
+reason = "Indirect: @hono/node-server@1.19.9 pinned by @modelcontextprotocol/sdk"
+
+[[IgnoredVulns]]
+id = "GHSA-gq3j-xvxp-8hrf"
+ignoreUntil = 2026-06-23
+reason = "Indirect: hono@4.11.8 pinned by @modelcontextprotocol/sdk"
+
+[[IgnoredVulns]]
+id = "GHSA-5pq2-9x2x-5p6w"
+ignoreUntil = 2026-06-23
+reason = "Indirect: hono@4.11.8 pinned by @modelcontextprotocol/sdk"
+
+[[IgnoredVulns]]
+id = "GHSA-p6xx-57qc-3wxr"
+ignoreUntil = 2026-06-23
+reason = "Indirect: hono@4.11.8 pinned by @modelcontextprotocol/sdk"
+
+[[IgnoredVulns]]
+id = "GHSA-q5qw-h33p-qvwr"
+ignoreUntil = 2026-06-23
+reason = "Indirect: hono@4.11.8 pinned by @modelcontextprotocol/sdk"
+
+[[IgnoredVulns]]
+id = "GHSA-v8w9-8mx6-g223"
+ignoreUntil = 2026-06-23
+reason = "Indirect: hono@4.11.8 pinned by @modelcontextprotocol/sdk"
+
+[[IgnoredVulns]]
+id = "GHSA-26pp-8wgv-hjvm"
+ignoreUntil = 2026-06-23
+reason = "Indirect: hono@4.11.8 pinned by @modelcontextprotocol/sdk"
+
+[[IgnoredVulns]]
+id = "GHSA-r5rp-j6wh-rvv4"
+ignoreUntil = 2026-06-23
+reason = "Indirect: hono@4.11.8 pinned by @modelcontextprotocol/sdk"
+
+[[IgnoredVulns]]
+id = "GHSA-wmmm-f939-6g9c"
+ignoreUntil = 2026-06-23
+reason = "Indirect: hono@4.11.8 pinned by @modelcontextprotocol/sdk"
+
+[[IgnoredVulns]]
+id = "GHSA-xf4j-xp2r-rqqx"
+ignoreUntil = 2026-06-23
+reason = "Indirect: hono@4.11.8 pinned by @modelcontextprotocol/sdk"
+
+[[IgnoredVulns]]
+id = "GHSA-xpcf-pg52-r92g"
+ignoreUntil = 2026-06-23
+reason = "Indirect: hono@4.11.8 pinned by @modelcontextprotocol/sdk"
+
+[[IgnoredVulns]]
+id = "GHSA-458j-xx4x-4375"
+ignoreUntil = 2026-06-23
+reason = "Indirect: hono@4.11.8 pinned by @modelcontextprotocol/sdk"
 
 [[IgnoredVulns]]
 id = "GHSA-46wh-pxpv-q5gq"
 ignoreUntil = 2026-06-23
 reason = "Indirect: express-rate-limit via @modelcontextprotocol/sdk"
-
-[[IgnoredVulns]]
-id = "GHSA-gq3j-xvxp-8hrf"
-ignoreUntil = 2026-06-23
-reason = "Indirect: hono via @modelcontextprotocol/sdk"
-
-[[IgnoredVulns]]
-id = "GHSA-5pq2-9x2x-5p6w"
-ignoreUntil = 2026-06-23
-reason = "Indirect: hono via @modelcontextprotocol/sdk"
-
-[[IgnoredVulns]]
-id = "GHSA-p6xx-57qc-3wxr"
-ignoreUntil = 2026-06-23
-reason = "Indirect: hono via @modelcontextprotocol/sdk"
-
-[[IgnoredVulns]]
-id = "GHSA-q5qw-h33p-qvwr"
-ignoreUntil = 2026-06-23
-reason = "Indirect: hono via @modelcontextprotocol/sdk"
-
-[[IgnoredVulns]]
-id = "GHSA-v8w9-8mx6-g223"
-ignoreUntil = 2026-06-23
-reason = "Indirect: hono via @modelcontextprotocol/sdk"
-
-[[IgnoredVulns]]
-id = "GHSA-92pp-h63x-v22m"
-ignoreUntil = 2026-06-23
-reason = "Indirect: @hono/node-server via @modelcontextprotocol/sdk"
-
-[[IgnoredVulns]]
-id = "GHSA-26pp-8wgv-hjvm"
-ignoreUntil = 2026-06-23
-reason = "Indirect: hono via @modelcontextprotocol/sdk"
-
-[[IgnoredVulns]]
-id = "GHSA-r5rp-j6wh-rvv4"
-ignoreUntil = 2026-06-23
-reason = "Indirect: hono via @modelcontextprotocol/sdk"
-
-[[IgnoredVulns]]
-id = "GHSA-wmmm-f939-6g9c"
-ignoreUntil = 2026-06-23
-reason = "Indirect: hono via @modelcontextprotocol/sdk"
-
-[[IgnoredVulns]]
-id = "GHSA-xf4j-xp2r-rqqx"
-ignoreUntil = 2026-06-23
-reason = "Indirect: hono via @modelcontextprotocol/sdk"
-
-[[IgnoredVulns]]
-id = "GHSA-xpcf-pg52-r92g"
-ignoreUntil = 2026-06-23
-reason = "Indirect: hono via @modelcontextprotocol/sdk"
 
 # --- eslint / @typescript-eslint transitive deps ---
 
@@ -129,8 +136,3 @@ reason = "Indirect: picomatch via micromatch/chokidar (transitive)"
 id = "GHSA-f886-m6hf-6m8v"
 ignoreUntil = 2026-06-23
 reason = "Indirect: brace-expansion via minimatch (eslint, @typescript-eslint)"
-
-
-[[IgnoredVulns]]
-id = "GHSA-458j-xx4x-4375"
-reason = "hono 4.12.12 → 4.12.14 medium severity, indirect exposure only"


### PR DESCRIPTION
Remove osv-scanner.toml ignores for hono CVEs that are already fixed in the current hono version (4.12.14+).\n\n🍊