### PR TITLE
test: boost unit test coverage

### DIFF
--- a/mcp/__tests__/tools-shared.test.ts
+++ b/mcp/__tests__/tools-shared.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import {
+  stripUndefined,
+  tryParseJson,
+  validateJson,
+  parseLocalDate,
+} from "../tools/shared";
+
+describe("stripUndefined", () => {
+  test("removes keys with undefined values", () => {
+    expect(stripUndefined({ a: 1, b: undefined, c: "x" })).toEqual({ a: 1, c: "x" });
+  });
+
+  test("keeps null values", () => {
+    expect(stripUndefined({ a: null, b: undefined })).toEqual({ a: null });
+  });
+
+  test("returns empty object when all values are undefined", () => {
+    expect(stripUndefined({ a: undefined, b: undefined })).toEqual({});
+  });
+
+  test("keeps falsy (but defined) values", () => {
+    expect(stripUndefined({ a: 0, b: "", c: false })).toEqual({ a: 0, b: "", c: false });
+  });
+});
+
+describe("tryParseJson", () => {
+  test("parses valid JSON objects", () => {
+    expect(tryParseJson('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  test("parses valid JSON arrays", () => {
+    expect(tryParseJson("[1,2,3]")).toEqual([1, 2, 3]);
+  });
+
+  test("returns raw string on parse failure", () => {
+    expect(tryParseJson("not json")).toBe("not json");
+  });
+
+  test("returns raw string for empty input", () => {
+    expect(tryParseJson("")).toBe("");
+  });
+});
+
+describe("validateJson", () => {
+  test("returns undefined for valid JSON", () => {
+    expect(validateJson('{"a":1}')).toBeUndefined();
+    expect(validateJson("[1,2]")).toBeUndefined();
+    expect(validateJson('"str"')).toBeUndefined();
+  });
+
+  test("returns error message for invalid JSON", () => {
+    const result = validateJson("not json");
+    expect(typeof result).toBe("string");
+    expect(result).toBeTruthy();
+  });
+
+  test("returns error message for empty string", () => {
+    const result = validateJson("");
+    expect(typeof result).toBe("string");
+  });
+});
+
+describe("parseLocalDate", () => {
+  test("parses YYYY-MM-DD at local midnight", () => {
+    const d = parseLocalDate("2024-03-15");
+    expect(d).not.toBeNull();
+    expect(d?.getFullYear()).toBe(2024);
+    expect(d?.getMonth()).toBe(2); // March, 0-indexed
+    expect(d?.getDate()).toBe(15);
+    expect(d?.getHours()).toBe(0);
+    expect(d?.getMinutes()).toBe(0);
+  });
+
+  test("parses YYYY-MM-DD with time suffix", () => {
+    const d = parseLocalDate("2024-01-01T12:34:56");
+    expect(d).not.toBeNull();
+    expect(d?.getFullYear()).toBe(2024);
+    expect(d?.getMonth()).toBe(0);
+    expect(d?.getDate()).toBe(1);
+    // Always midnight local time, ignoring time portion
+    expect(d?.getHours()).toBe(0);
+  });
+
+  test("returns null for invalid format", () => {
+    expect(parseLocalDate("not-a-date")).toBeNull();
+    expect(parseLocalDate("2024/03/15")).toBeNull();
+    expect(parseLocalDate("")).toBeNull();
+  });
+});

--- a/src/__tests__/db/attachments.test.ts
+++ b/src/__tests__/db/attachments.test.ts
@@ -181,4 +181,66 @@ describe("attachmentsRepo", () => {
       expect(await attachmentsRepo.countByPolicyId(9999)).toBe(0);
     });
   });
+
+  describe("countGroupedByPolicyIds", () => {
+    test("returns empty map when input is empty", async () => {
+      const result = await attachmentsRepo.countGroupedByPolicyIds([]);
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    test("returns counts grouped by policy id", async () => {
+      // Create a second policy so we can group across multiple policies.
+      const member = await membersRepo.create({
+        name: "李四",
+        relation: "Spouse",
+        birthDate: "1987-05-05",
+      });
+      const policy2 = await policiesRepo.create({
+        applicantId: member.id,
+        insuredType: "Member",
+        insuredMemberId: member.id,
+        category: "Life",
+        insurerName: "平安人寿",
+        productName: "平安福",
+        policyNumber: `POL2-${Date.now()}`,
+        sumAssured: 300000,
+        premium: 8000,
+        paymentFrequency: "Yearly",
+        effectiveDate: "2024-02-01",
+      } satisfies NewPolicy);
+
+      await attachmentsRepo.create(
+        createTestAttachment({ filename: "p1-a.pdf" }),
+      );
+      await attachmentsRepo.create(
+        createTestAttachment({ filename: "p1-b.pdf" }),
+      );
+      await attachmentsRepo.create(
+        createTestAttachment({
+          policyId: policy2.id,
+          filename: "p2-a.pdf",
+          r2Key: `policies/${policy2.id}/${crypto.randomUUID()}.pdf`,
+        }),
+      );
+
+      const result = await attachmentsRepo.countGroupedByPolicyIds([
+        testPolicyId,
+        policy2.id,
+        9999, // nonexistent policy should not appear
+      ]);
+
+      expect(result.get(testPolicyId)).toBe(2);
+      expect(result.get(policy2.id)).toBe(1);
+      expect(result.has(9999)).toBe(false);
+      expect(result.size).toBe(2);
+    });
+
+    test("omits policies with zero attachments", async () => {
+      const result = await attachmentsRepo.countGroupedByPolicyIds([
+        testPolicyId,
+      ]);
+      expect(result.size).toBe(0);
+    });
+  });
 });

--- a/src/__tests__/db/others.test.ts
+++ b/src/__tests__/db/others.test.ts
@@ -83,6 +83,34 @@ describe("Other Repositories", () => {
       expect(await beneficiariesRepo.deleteByPolicyId(testPolicyId)).toBe(2);
       expect(await beneficiariesRepo.findByPolicyId(testPolicyId)).toHaveLength(0);
     });
+
+    test("findByMemberId returns beneficiaries linked to a member", async () => {
+      const beneficiaryMember = await membersRepo.create({
+        name: "王五",
+        relation: "Child",
+        birthDate: "2015-06-01",
+      });
+
+      await beneficiariesRepo.create({
+        policyId: testPolicyId,
+        memberId: beneficiaryMember.id,
+        sharePercent: 60,
+        rankOrder: 1,
+      });
+      await beneficiariesRepo.create({
+        policyId: testPolicyId,
+        externalName: "外部受益人",
+        sharePercent: 40,
+        rankOrder: 2,
+      });
+
+      const linked = await beneficiariesRepo.findByMemberId(beneficiaryMember.id);
+      expect(linked).toHaveLength(1);
+      expect(linked[0]?.memberId).toBe(beneficiaryMember.id);
+      expect(linked[0]?.sharePercent).toBe(60);
+
+      expect(await beneficiariesRepo.findByMemberId(9999)).toEqual([]);
+    });
   });
 
   describe("paymentsRepo", () => {

--- a/src/__tests__/format.test.ts
+++ b/src/__tests__/format.test.ts
@@ -54,6 +54,7 @@ describe("formatCurrencyFull", () => {
 
   test("formats negative values", () => {
     const result = formatCurrencyFull(-100.5);
+    expect(result).toContain("-");
     expect(result).toContain("100.50");
   });
 });

--- a/src/__tests__/format.test.ts
+++ b/src/__tests__/format.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { formatCurrency, formatCurrencyFull } from "@/lib/format";
+
+describe("formatCurrency", () => {
+  test("formats values >= 10000 as 万 without decimals when exact", () => {
+    expect(formatCurrency(10000)).toBe("1万");
+    expect(formatCurrency(50000)).toBe("5万");
+    expect(formatCurrency(1000000)).toBe("100万");
+  });
+
+  test("formats values >= 10000 with 1 decimal when not exact", () => {
+    expect(formatCurrency(12345)).toBe("1.2万");
+    expect(formatCurrency(15000)).toBe("1.5万");
+    expect(formatCurrency(99999)).toBe("10.0万");
+  });
+
+  test("formats values < 10000 as CNY currency with no decimals", () => {
+    const result = formatCurrency(500);
+    expect(result).toContain("500");
+    expect(result).not.toContain(".");
+  });
+
+  test("formats zero", () => {
+    const result = formatCurrency(0);
+    expect(result).toContain("0");
+  });
+
+  test("formats values just below threshold", () => {
+    const result = formatCurrency(9999);
+    expect(result).toContain("9,999");
+  });
+});
+
+describe("formatCurrencyFull", () => {
+  test("formats with exactly 2 decimals", () => {
+    const result = formatCurrencyFull(1234.5);
+    expect(result).toContain("1,234.50");
+  });
+
+  test("formats zero with 2 decimals", () => {
+    const result = formatCurrencyFull(0);
+    expect(result).toContain("0.00");
+  });
+
+  test("rounds to 2 decimals", () => {
+    const result = formatCurrencyFull(1.999);
+    expect(result).toContain("2.00");
+  });
+
+  test("formats large values with 2 decimals", () => {
+    const result = formatCurrencyFull(1234567.89);
+    expect(result).toContain("1,234,567.89");
+  });
+
+  test("formats negative values", () => {
+    const result = formatCurrencyFull(-100.5);
+    expect(result).toContain("100.50");
+  });
+});

--- a/src/__tests__/policies-route.test.ts
+++ b/src/__tests__/policies-route.test.ts
@@ -200,6 +200,39 @@ describe("GET /api/policies/[id]", () => {
     expect(body.status).toBe("Active");
   });
 
+  test("populates insuredAssetName when insuredAssetId matches a known asset", async () => {
+    policiesFindById.mockImplementation(() =>
+      Promise.resolve({
+        id: 2,
+        policyNumber: "POL-ASSET",
+        productName: "财产险",
+        insurerName: "人保财险",
+        insuredMemberId: null,
+        insuredAssetId: 10, // Matches fixture asset { id: 10, name: "房产A" }
+        applicantId: 1,
+        insuredType: "Asset",
+        category: "Property",
+        subCategory: null,
+        channel: null,
+        sumAssured: 500000,
+        premium: 2000,
+        paymentFrequency: "Yearly",
+        effectiveDate: "2024-01-01",
+        expiryDate: null,
+        status: "Active",
+      }),
+    );
+
+    const req = new Request("http://localhost/api/policies/2");
+
+    const res = await GET(req as unknown as NextRequest, ctx("2"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.insuredAssetId).toBe(10);
+    expect(body.insuredAssetName).toBe("房产A");
+    expect(body.applicantName).toBe("张三");
+  });
+
   test("maps missing member/asset names to '未知'", async () => {
     policiesFindById.mockImplementation(() =>
       Promise.resolve({

--- a/src/__tests__/policies-route.test.ts
+++ b/src/__tests__/policies-route.test.ts
@@ -407,14 +407,26 @@ describe("DELETE /api/policies/[id]", () => {
     policiesFindById.mockImplementation(() => Promise.resolve({ id: 1 }));
 
     const req = new Request("http://localhost/api/policies/1", { method: "DELETE" });
-     
+
     const res = await DELETE(req as unknown as NextRequest, ctx("1"));
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ success: true });
+
+    // Behavioral assertions: the batch path must atomically remove the
+    // policy and clean up every associated record type, regardless of how
+    // many statements the implementation decomposes that into.
     expect(batchExecute).toHaveBeenCalledTimes(1);
-    const call = batchExecute.mock.calls[0] as unknown as [Array<{ sql: string }>];
+    const call = batchExecute.mock.calls[0] as unknown as [Array<{ sql: string; params?: unknown[] }>];
     const statements = call[0];
-    expect(statements).toHaveLength(6);
+    const joined = statements.map((s) => s.sql).join("\n");
+    expect(joined).toContain("DELETE FROM policies");
+    expect(joined).toMatch(/attachments/);
+    expect(joined).toMatch(/beneficiaries/);
+    expect(joined).toMatch(/payments/);
+    expect(joined).toMatch(/cash_values/);
+    expect(joined).toMatch(/coverage_items/);
+    // The policy row itself must be removed last so FK-dependent rows are
+    // deleted first (D1 enforces foreign_keys=ON).
     expect(statements.at(-1)?.sql).toContain("DELETE FROM policies");
   });
 

--- a/src/__tests__/policies-route.test.ts
+++ b/src/__tests__/policies-route.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Unit tests for GET / PUT / DELETE handlers in
+ * src/app/api/policies/[id]/route.ts using mocked repos.
+ *
+ * These tests cover the success paths that existing coverage was missing:
+ * - GET: 200 success, 400 invalid id, 404 missing
+ * - PUT: 200 success, 400 invalid id, 409 duplicate policy number
+ * - DELETE: 200 success (batch + non-batch), 400 invalid id, 404 missing
+ */
+import { describe, expect, test, mock, beforeEach } from "bun:test";
+import type { NextRequest } from "next/server";
+
+// --- Mock setup (must precede route import) ---
+
+const policiesFindById = mock(() => Promise.resolve<Record<string, unknown> | undefined>(undefined));
+const policiesUpdate = mock(() => Promise.resolve<Record<string, unknown> | undefined>(undefined));
+const policiesDelete = mock(() => Promise.resolve(true));
+
+const insurersFindOrCreate = mock(() =>
+  Promise.resolve({ id: 42, name: "示例保险", created: false }),
+);
+const insurersDelete = mock(() => Promise.resolve(true));
+
+const membersFindAll = mock(() =>
+  Promise.resolve([
+    { id: 1, name: "张三" },
+    { id: 2, name: "李四" },
+  ]),
+);
+const assetsFindAll = mock(() =>
+  Promise.resolve([
+    { id: 10, name: "房产A" },
+  ]),
+);
+
+const attachmentsFindByPolicyId = mock(() => Promise.resolve<Array<{ r2Key: string }>>([]));
+const attachmentsDeleteByPolicyId = mock(() => Promise.resolve(0));
+const beneficiariesDeleteByPolicyId = mock(() => Promise.resolve(0));
+const paymentsDeleteByPolicyId = mock(() => Promise.resolve(0));
+const cashValuesDeleteByPolicyId = mock(() => Promise.resolve(0));
+const coverageItemsDeleteByPolicyId = mock(() => Promise.resolve(0));
+
+const batchExecute = mock(() => Promise.resolve());
+
+const mockRepos = {
+  policies: {
+    findById: policiesFindById,
+    update: policiesUpdate,
+    delete: policiesDelete,
+  },
+  insurers: {
+    findOrCreate: insurersFindOrCreate,
+    delete: insurersDelete,
+  },
+  members: { findAll: membersFindAll },
+  assets: { findAll: assetsFindAll },
+  attachments: {
+    findByPolicyId: attachmentsFindByPolicyId,
+    deleteByPolicyId: attachmentsDeleteByPolicyId,
+  },
+  beneficiaries: { deleteByPolicyId: beneficiariesDeleteByPolicyId },
+  payments: { deleteByPolicyId: paymentsDeleteByPolicyId },
+  cashValues: { deleteByPolicyId: cashValuesDeleteByPolicyId },
+  coverageItems: { deleteByPolicyId: coverageItemsDeleteByPolicyId },
+};
+
+let includeBatch = true;
+
+mock.module("@/lib/api-helpers", () => ({
+  getReposFromRequest: () =>
+    Promise.resolve(
+      includeBatch
+        ? { repos: mockRepos, targetDb: "test" as const, batchExecute }
+        : { repos: mockRepos, targetDb: "test" as const },
+    ),
+}));
+
+// r2-client: always throw so DELETE code path skips R2 cleanup.
+mock.module("@/lib/r2-client", () => ({
+  getR2ClientFromEnv: () => {
+    throw new Error("R2 env not configured");
+  },
+}));
+
+// Route handler imported AFTER mock.module
+const { GET, PUT, DELETE } = await import("@/app/api/policies/[id]/route");
+
+// --- Helpers ---
+
+function ctx(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function resetAllMocks() {
+  policiesFindById.mockReset();
+  policiesUpdate.mockReset();
+  policiesDelete.mockReset();
+  insurersFindOrCreate.mockReset();
+  insurersDelete.mockReset();
+  membersFindAll.mockReset();
+  assetsFindAll.mockReset();
+  attachmentsFindByPolicyId.mockReset();
+  attachmentsDeleteByPolicyId.mockReset();
+  beneficiariesDeleteByPolicyId.mockReset();
+  paymentsDeleteByPolicyId.mockReset();
+  cashValuesDeleteByPolicyId.mockReset();
+  coverageItemsDeleteByPolicyId.mockReset();
+  batchExecute.mockReset();
+
+  // Re-establish default implementations
+  membersFindAll.mockImplementation(() =>
+    Promise.resolve([
+      { id: 1, name: "张三" },
+      { id: 2, name: "李四" },
+    ]),
+  );
+  assetsFindAll.mockImplementation(() =>
+    Promise.resolve([{ id: 10, name: "房产A" }]),
+  );
+  attachmentsFindByPolicyId.mockImplementation(() => Promise.resolve([]));
+  attachmentsDeleteByPolicyId.mockImplementation(() => Promise.resolve(0));
+  beneficiariesDeleteByPolicyId.mockImplementation(() => Promise.resolve(0));
+  paymentsDeleteByPolicyId.mockImplementation(() => Promise.resolve(0));
+  cashValuesDeleteByPolicyId.mockImplementation(() => Promise.resolve(0));
+  coverageItemsDeleteByPolicyId.mockImplementation(() => Promise.resolve(0));
+  policiesDelete.mockImplementation(() => Promise.resolve(true));
+  insurersFindOrCreate.mockImplementation(() =>
+    Promise.resolve({ id: 42, name: "示例保险", created: false }),
+  );
+  insurersDelete.mockImplementation(() => Promise.resolve(true));
+  batchExecute.mockImplementation(() => Promise.resolve());
+  includeBatch = true;
+}
+
+// --- GET ---
+
+describe("GET /api/policies/[id]", () => {
+  beforeEach(resetAllMocks);
+
+  test("returns 400 for non-numeric id", async () => {
+    const req = new Request("http://localhost/api/policies/abc");
+     
+    const res = await GET(req as unknown as NextRequest, ctx("abc"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid id" });
+  });
+
+  test("returns 404 when policy is missing", async () => {
+    policiesFindById.mockImplementation(() => Promise.resolve(undefined));
+    const req = new Request("http://localhost/api/policies/1");
+     
+    const res = await GET(req as unknown as NextRequest, ctx("1"));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Policy not found" });
+  });
+
+  test("returns 200 with enriched member + asset names", async () => {
+    policiesFindById.mockImplementation(() =>
+      Promise.resolve({
+        id: 1,
+        policyNumber: "POL-1",
+        productName: "平安福",
+        insurerName: "平安人寿",
+        insuredMemberId: 1,
+        insuredAssetId: null,
+        applicantId: 2,
+        insuredType: "Member",
+        category: "Life",
+        subCategory: null,
+        channel: null,
+        sumAssured: 100000,
+        premium: 5000,
+        paymentFrequency: "Yearly",
+        paymentYears: 20,
+        totalPayments: 20,
+        renewalType: null,
+        paymentAccount: null,
+        nextDueDate: null,
+        effectiveDate: "2024-01-01",
+        expiryDate: null,
+        hesitationEndDate: null,
+        waitingDays: null,
+        guaranteedRenewalYears: null,
+        status: "Active",
+        deathBenefit: null,
+        policyFilePath: null,
+        notes: null,
+      }),
+    );
+
+    const req = new Request("http://localhost/api/policies/1");
+     
+    const res = await GET(req as unknown as NextRequest, ctx("1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(1);
+    expect(body.insuredName).toBe("张三");
+    expect(body.applicantName).toBe("李四");
+    expect(body.insuredAssetName).toBeNull();
+    expect(body.status).toBe("Active");
+  });
+
+  test("maps missing member/asset names to '未知'", async () => {
+    policiesFindById.mockImplementation(() =>
+      Promise.resolve({
+        id: 1,
+        policyNumber: "POL-2",
+        productName: "p",
+        insurerName: "i",
+        insuredMemberId: null,
+        insuredAssetId: 999, // Unknown asset id
+        applicantId: 888, // Unknown applicant id
+        insuredType: "Asset",
+        category: "Property",
+        subCategory: null,
+        channel: null,
+        sumAssured: 0,
+        premium: 0,
+        paymentFrequency: "Single",
+        effectiveDate: "2024-01-01",
+        expiryDate: null,
+        status: "Active",
+      }),
+    );
+
+    const req = new Request("http://localhost/api/policies/1");
+     
+    const res = await GET(req as unknown as NextRequest, ctx("1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.insuredName).toBe("未知");
+    expect(body.insuredAssetName).toBeNull();
+    expect(body.applicantName).toBe("未知");
+  });
+});
+
+// --- PUT ---
+
+describe("PUT /api/policies/[id]", () => {
+  beforeEach(resetAllMocks);
+
+  function putReq(body: Record<string, unknown>) {
+    return new Request("http://localhost/api/policies/1", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  test("returns 400 for non-numeric id", async () => {
+     
+    const res = await PUT(putReq({}) as unknown as NextRequest, ctx("abc"));
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 404 when policy missing before update", async () => {
+    policiesFindById.mockImplementation(() => Promise.resolve(undefined));
+     
+    const res = await PUT(putReq({ productName: "x" }) as unknown as NextRequest, ctx("1"));
+    expect(res.status).toBe(404);
+  });
+
+  test("returns 200 on successful update with Member insuredType clearing asset", async () => {
+    policiesFindById.mockImplementation(() =>
+      Promise.resolve({ id: 1, status: "Active" }),
+    );
+    policiesUpdate.mockImplementation(() =>
+      Promise.resolve({
+        id: 1,
+        policyNumber: "POL-1",
+        productName: "新产品",
+        insurerName: "平安人寿",
+        category: "Life",
+        status: "Active",
+      }),
+    );
+
+    const res = await PUT(
+       
+      putReq({
+        insurerName: "平安人寿",
+        productName: "新产品",
+        category: "Life",
+        insuredType: "Member",
+        insuredMemberId: 1,
+        insuredAssetId: 99, // Should be cleared
+      }) as unknown as NextRequest,
+      ctx("1"),
+    );
+    expect(res.status).toBe(200);
+    const call = policiesUpdate.mock.calls[0] as unknown as [number, Record<string, unknown>];
+    const updateArg = call[1];
+    expect(updateArg.insuredAssetId).toBeNull();
+    expect(updateArg.insuredMemberId).toBe(1);
+  });
+
+  test("Asset insuredType clears member id", async () => {
+    policiesFindById.mockImplementation(() => Promise.resolve({ id: 1 }));
+    policiesUpdate.mockImplementation(() =>
+      Promise.resolve({ id: 1, category: "Property", status: "Active" }),
+    );
+
+     
+    await PUT(
+      putReq({
+        productName: "p",
+        category: "Property",
+        insuredType: "Asset",
+        insuredMemberId: 5,
+        insuredAssetId: 10,
+      }) as unknown as NextRequest,
+      ctx("1"),
+    );
+    const call = policiesUpdate.mock.calls[0] as unknown as [number, Record<string, unknown>];
+    const updateArg = call[1];
+    expect(updateArg.insuredMemberId).toBeNull();
+    expect(updateArg.insuredAssetId).toBe(10);
+  });
+
+  test("returns 409 for UNIQUE policy_number violation", async () => {
+    policiesFindById.mockImplementation(() => Promise.resolve({ id: 1 }));
+    policiesUpdate.mockImplementation(() =>
+      Promise.reject(new Error("UNIQUE constraint failed: policies.policy_number")),
+    );
+
+     
+    const res = await PUT(
+      putReq({ productName: "p", category: "Life" }) as unknown as NextRequest,
+      ctx("1"),
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("保单编号已存在");
+  });
+
+  test("returns 500 for generic update errors", async () => {
+    policiesFindById.mockImplementation(() => Promise.resolve({ id: 1 }));
+    policiesUpdate.mockImplementation(() =>
+      Promise.reject(new Error("random DB failure")),
+    );
+
+     
+    const res = await PUT(
+      putReq({ productName: "p", category: "Life" }) as unknown as NextRequest,
+      ctx("1"),
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("更新保单失败");
+  });
+});
+
+// --- DELETE ---
+
+describe("DELETE /api/policies/[id]", () => {
+  beforeEach(resetAllMocks);
+
+  test("returns 400 for non-numeric id", async () => {
+    const req = new Request("http://localhost/api/policies/abc", { method: "DELETE" });
+     
+    const res = await DELETE(req as unknown as NextRequest, ctx("abc"));
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 404 when policy missing", async () => {
+    policiesFindById.mockImplementation(() => Promise.resolve(undefined));
+    const req = new Request("http://localhost/api/policies/1", { method: "DELETE" });
+     
+    const res = await DELETE(req as unknown as NextRequest, ctx("1"));
+    expect(res.status).toBe(404);
+  });
+
+  test("returns success via batch path when batchExecute is available", async () => {
+    policiesFindById.mockImplementation(() => Promise.resolve({ id: 1 }));
+
+    const req = new Request("http://localhost/api/policies/1", { method: "DELETE" });
+     
+    const res = await DELETE(req as unknown as NextRequest, ctx("1"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(batchExecute).toHaveBeenCalledTimes(1);
+    const call = batchExecute.mock.calls[0] as unknown as [Array<{ sql: string }>];
+    const statements = call[0];
+    expect(statements).toHaveLength(6);
+    expect(statements.at(-1)?.sql).toContain("DELETE FROM policies");
+  });
+
+  test("returns success via non-batch fallback path", async () => {
+    includeBatch = false;
+    policiesFindById.mockImplementation(() => Promise.resolve({ id: 1 }));
+
+    const req = new Request("http://localhost/api/policies/1", { method: "DELETE" });
+     
+    const res = await DELETE(req as unknown as NextRequest, ctx("1"));
+    expect(res.status).toBe(200);
+    expect(attachmentsDeleteByPolicyId).toHaveBeenCalledWith(1);
+    expect(beneficiariesDeleteByPolicyId).toHaveBeenCalledWith(1);
+    expect(paymentsDeleteByPolicyId).toHaveBeenCalledWith(1);
+    expect(cashValuesDeleteByPolicyId).toHaveBeenCalledWith(1);
+    expect(coverageItemsDeleteByPolicyId).toHaveBeenCalledWith(1);
+    expect(policiesDelete).toHaveBeenCalledWith(1);
+  });
+
+  test("skips R2 cleanup gracefully when env missing", async () => {
+    policiesFindById.mockImplementation(() => Promise.resolve({ id: 1 }));
+    attachmentsFindByPolicyId.mockImplementation(() =>
+      Promise.resolve([{ r2Key: "policies/1/a.pdf" }]),
+    );
+
+    const req = new Request("http://localhost/api/policies/1", { method: "DELETE" });
+     
+    const res = await DELETE(req as unknown as NextRequest, ctx("1"));
+    // R2 env-missing should NOT turn a successful DB delete into 500
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Coverage Boost

Coverage: 82.88% → improved (+655 lines tests)

### Changes
- 4 commits adding/expanding unit tests
- No source code changes, tests only
- Excluded React/view/chart components per convention
