### PR TITLE
fix(ui): align bg-card usage to B05 luminance spec

### DIFF
--- a/apps/web/src/app/dashboard-content.tsx
+++ b/apps/web/src/app/dashboard-content.tsx
@@ -41,7 +41,7 @@ function StatCard({ label, value, iconName, index }: StatCardData & { index: num
     >
       <div className="flex items-center justify-between">
         <span className="text-sm text-muted-foreground">{label}</span>
-        <div className="rounded-md bg-card p-2">
+        <div className="rounded-md bg-background p-2">
           <Icon className="h-4 w-4 text-primary" strokeWidth={1.5} />
         </div>
       </div>

--- a/apps/web/src/components/renewal/summary-cards.tsx
+++ b/apps/web/src/components/renewal/summary-cards.tsx
@@ -27,7 +27,7 @@ function StatCard({ label, value, subValue, icon: Icon, variant = "default" }: S
     <div className="rounded-card bg-secondary p-6">
       <div className="flex items-center justify-between">
         <span className="text-sm text-muted-foreground">{label}</span>
-        <div className="rounded-md bg-card p-2">
+        <div className="rounded-md bg-background p-2">
           <Icon className={`h-4 w-4 ${iconColors[variant]}`} strokeWidth={1.5} />
         </div>
       </div>

--- a/apps/web/src/components/skeletons.tsx
+++ b/apps/web/src/components/skeletons.tsx
@@ -311,7 +311,7 @@ export function PolicyDetailSkeleton() {
           <Skeleton className="h-5 w-24 mb-4" />
           <div className="space-y-2">
             {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="rounded-widget bg-card p-3">
+              <div key={i} className="rounded-widget bg-secondary p-3">
                 <Skeleton className="h-4 w-32" />
                 <Skeleton className="mt-1 h-3 w-20" />
               </div>
@@ -324,7 +324,7 @@ export function PolicyDetailSkeleton() {
           <Skeleton className="h-5 w-20 mb-4" />
           <div className="space-y-2">
             {Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="rounded-widget bg-card p-3">
+              <div key={i} className="rounded-widget bg-secondary p-3">
                 <div className="flex justify-between">
                   <Skeleton className="h-4 w-16" />
                   <Skeleton className="h-4 w-12" />


### PR DESCRIPTION
Closes #34\n\nReplace misused bg-card (L1) with bg-secondary (L2) for content cards inside the floating island, per Basalt B05 spec.