### PR TITLE
ci: fix wrangler-action deploy with bun packageManager

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy
           workingDirectory: apps/worker
+          packageManager: bun
 
       - name: Verify /api/live reports new version
         run: |
@@ -144,6 +145,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy
           workingDirectory: apps/worker
+          packageManager: bun
 
       - name: Verify /api/live responds 200
         run: |


### PR DESCRIPTION
wrangler-action 内部默认用 npm 安装 wrangler，但项目使用 bun。npm 不支持 workspace: 协议和某些 overrides 写法，导致 Deploy Worker step 失败。\n\n修复：添加 packageManager: bun 让 wrangler-action 使用 bun 安装。