### PR TITLE
chore(deps): bump @types/node 25.9.2 → 25.9.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.1",
         "@types/bun": "1.3.14",
-        "@types/node": "25.9.2",
+        "@types/node": "25.9.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitest/coverage-v8": "^4.1.8",
@@ -606,7 +606,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.1",
     "@types/bun": "1.3.14",
-    "@types/node": "25.9.2",
+    "@types/node": "25.9.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitest/coverage-v8": "^4.1.8",


### PR DESCRIPTION
## Summary

Patch upgrade of `@types/node` from 25.9.2 to 25.9.3 (devDependencies).

Closes #94.

## Verification

- `bun run typecheck` — passing
- `bun run test` — 247/247 passing across 32 files
- Pre-commit hooks (lint-staged, typecheck, gitleaks) — passing